### PR TITLE
refactor[buffer manager]: move buffer operations into a dedicated `BufferManager` struct

### DIFF
--- a/src/wayland/buffer/manager.rs
+++ b/src/wayland/buffer/manager.rs
@@ -1,16 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    manager.rs:
+        Provides the `BufferManager` structure for alloocating and using pixel buffers.
+*/
+
+use crate::shared::ffi::RendererEvent;
+use crate::wayland::state::WaylandState;
 use std::os::raw::c_void;
 use wayland_client::protocol::wl_buffer;
 use wayland_client::protocol::{wl_buffer::WlBuffer, wl_shm::WlShm};
 use wayland_client::{Connection, Dispatch, QueueHandle};
-use crate::shared::ffi::RendererEvent;
-use crate::wayland::state::WaylandState;
 
 /// Represents a buffer for storing pixel data
-/// 
+///
 /// This structure contains a `WlBuffer` object for use in Wayland contexts,
 /// as well as a raw pointer to the buffer's memory for use in external rendering
-/// code. 
-/// 
+/// code.
+///
 /// The `in_use` member is a boolean value that dictates whether the buffer is currently
 /// being used by the Wayland compositor. If this is set to `true`, the buffer's data
 /// should not be modified, as this violates Wayland protocol.
@@ -21,9 +29,9 @@ pub struct Buffer {
 }
 
 /// `BufferManager` is a structure that can be used for allocating `Buffer` objects.
-/// 
+///
 /// This structure contains various functions for operating on these buffers.
-/// 
+///
 /// The `width`, `height`, and `shm` members need to be set before this structure is
 /// ready to allocate buffers. This can be done via the `set_output_dimensions` and
 /// `set_shm` methods respectively.
@@ -36,7 +44,7 @@ pub struct BufferManager {
 
 impl BufferManager {
     /// Create a new `BufferManager`, with the buffers array initialized
-    /// 
+    ///
     /// `set_output_dimensions` and `set_shm` need to be used before the `BufferManager` object is
     /// ready to allocate buffers.
     pub fn new() -> Self {
@@ -73,7 +81,7 @@ impl BufferManager {
     }
 
     /// Release a buffer by index
-    /// 
+    ///
     /// This function sets the `in_use` member of the buffer specified by `index` to `false`.
     /// This function is intended to be used after receiving the `wl_buffer::Event::Release` event,
     /// signalling that the specified buffer has been released.

--- a/src/wayland/buffer/manager.rs
+++ b/src/wayland/buffer/manager.rs
@@ -1,0 +1,133 @@
+use std::os::raw::c_void;
+use wayland_client::protocol::wl_buffer;
+use wayland_client::protocol::{wl_buffer::WlBuffer, wl_shm::WlShm};
+use wayland_client::{Connection, Dispatch, QueueHandle};
+use crate::shared::ffi::RendererEvent;
+use crate::wayland::state::WaylandState;
+
+/// Represents a buffer for storing pixel data
+/// 
+/// This structure contains a `WlBuffer` object for use in Wayland contexts,
+/// as well as a raw pointer to the buffer's memory for use in external rendering
+/// code. 
+/// 
+/// The `in_use` member is a boolean value that dictates whether the buffer is currently
+/// being used by the Wayland compositor. If this is set to `true`, the buffer's data
+/// should not be modified, as this violates Wayland protocol.
+pub struct Buffer {
+    pub buffer: WlBuffer,
+    pub in_use: bool,
+    pub data: *mut u8,
+}
+
+/// `BufferManager` is a structure that can be used for allocating `Buffer` objects.
+/// 
+/// This structure contains various functions for operating on these buffers.
+/// 
+/// The `width`, `height`, and `shm` members need to be set before this structure is
+/// ready to allocate buffers. This can be done via the `set_output_dimensions` and
+/// `set_shm` methods respectively.
+pub struct BufferManager {
+    pub buffers: Option<Vec<Buffer>>,
+    pub shm: Option<WlShm>,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+}
+
+impl BufferManager {
+    /// Create a new `BufferManager`, with the buffers array initialized
+    /// 
+    /// `set_output_dimensions` and `set_shm` need to be used before the `BufferManager` object is
+    /// ready to allocate buffers.
+    pub fn new() -> Self {
+        Self {
+            buffers: Some(Vec::new()),
+            shm: None,
+            width: None,
+            height: None,
+        }
+    }
+
+    pub fn set_output_dimensions(&mut self, width: i32, height: i32) {
+        self.width = Some(width);
+        self.height = Some(height);
+    }
+
+    pub fn set_shm(&mut self, shm: WlShm) {
+        self.shm = Some(shm);
+    }
+
+    /// This function returns the dimensions of a display buffer in the format `(width, height, stride, size)`.
+    pub fn calculate_buffer_dimensions(
+        &self,
+    ) -> Result<(i32, i32, i32, i32), Box<dyn std::error::Error>> {
+        let width = self
+            .width
+            .ok_or::<Box<dyn std::error::Error>>("Invalid width".into())?;
+        let height = self
+            .height
+            .ok_or::<Box<dyn std::error::Error>>("Invalid height".into())?;
+        let stride = width * 4;
+
+        Ok((width, height, stride, height * stride))
+    }
+
+    /// Release a buffer by index
+    /// 
+    /// This function sets the `in_use` member of the buffer specified by `index` to `false`.
+    /// This function is intended to be used after receiving the `wl_buffer::Event::Release` event,
+    /// signalling that the specified buffer has been released.
+    pub fn release_buffer(&mut self, index: usize) -> Result<(), Box<dyn std::error::Error>> {
+        let buffers = self
+            .buffers
+            .as_mut()
+            .ok_or::<Box<dyn std::error::Error>>("Failed to obtain buffers array".into())?;
+
+        if index >= buffers.len() {
+            return Err("Buffer index out of range".into());
+        }
+
+        buffers[index].in_use = false;
+
+        Ok(())
+    }
+
+    /// Returns the next available buffer from the buffer store
+    pub fn find_available_buffer(&self) -> Option<&Buffer> {
+        self.buffers.as_ref()?.iter().find(|b| !b.in_use)
+    }
+
+    /// Searches for a `Buffer` matching the data provided by a `RendererEvent`
+    pub fn find_buffer_from_event(
+        &mut self,
+        event: &RendererEvent,
+    ) -> Result<&mut Buffer, Box<dyn std::error::Error>> {
+        let buffers = self.buffers.as_mut().ok_or("Buffers unavailable")?;
+
+        buffers
+            .iter_mut()
+            .find(|b| b.data as *mut c_void == event.buffer)
+            .ok_or("No matching buffer found".into())
+    }
+}
+
+impl Dispatch<WlBuffer, i32> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _proxy: &WlBuffer,
+        event: <WlBuffer as wayland_client::Proxy>::Event,
+        data: &i32,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_buffer::Event::Release => {
+                // Release the buffer so it can be used again
+                if let Err(e) = state.buffer_manager.release_buffer(*data as usize) {
+                    println!("{}", e);
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/wayland/buffer/mod.rs
+++ b/src/wayland/buffer/mod.rs
@@ -1,0 +1,2 @@
+pub mod manager;
+pub mod pool;

--- a/src/wayland/buffer/pool.rs
+++ b/src/wayland/buffer/pool.rs
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    pool.rs:
+        Contains operations relating to memory allocation for `BufferManager`
+*/
+
 use crate::wayland::buffer::manager::{Buffer, BufferManager};
 use crate::wayland::state::WaylandState;
 use nix::libc::{MAP_SHARED, PROT_READ, PROT_WRITE, ftruncate, mmap};

--- a/src/wayland/buffer/pool.rs
+++ b/src/wayland/buffer/pool.rs
@@ -1,35 +1,20 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (C) 2025, Nathan Gill
-
-/*
-    buffer.rs:
-        Buffer allocation and management for the renderer.
-*/
-
+use crate::wayland::buffer::manager::{Buffer, BufferManager};
 use crate::wayland::state::WaylandState;
 use nix::libc::{MAP_SHARED, PROT_READ, PROT_WRITE, ftruncate, mmap};
 use nix::sys::memfd::{MFdFlags, memfd_create};
-use std::os::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
-use std::os::raw::c_void;
-use wayland_client::EventQueue;
+use std::os::{
+    fd::{AsFd, AsRawFd, OwnedFd, RawFd},
+    raw::c_void,
+};
 use wayland_client::protocol::wl_shm;
 use wayland_client::protocol::wl_shm_pool::WlShmPool;
-use wayland_client::{
-    Connection, Dispatch, QueueHandle,
-    protocol::wl_buffer::{self, WlBuffer},
-};
+use wayland_client::{EventQueue, QueueHandle};
 
-pub struct Buffer {
-    pub buffer: WlBuffer,
-    pub in_use: bool,
-    pub data: *mut u8,
-}
-
-impl WaylandState {
+impl BufferManager {
     /// Safe wrapper for `mmap`
     ///
     /// The return value is a pointer to the memory-mapped region
-    pub fn map_file(
+    fn map_file(
         &self,
         len: usize,
         prot: i32,
@@ -65,7 +50,7 @@ impl WaylandState {
     fn allocate_buffer(
         &mut self,
         pool: &WlShmPool,
-        qh: &QueueHandle<Self>,
+        qh: &QueueHandle<WaylandState>,
         data_ptr: *mut c_void,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (width, height, stride, _) = self.calculate_buffer_dimensions()?;
@@ -96,25 +81,12 @@ impl WaylandState {
         Ok(())
     }
 
-    /// This function returns the dimensions of a display buffer in the format `(width, height, stride, size)`.
-    fn calculate_buffer_dimensions(
-        &self,
-    ) -> Result<(i32, i32, i32, i32), Box<dyn std::error::Error>> {
-        if self.width < 0 || self.height < 0 {
-            return Err("Invalid width or height".into());
-        }
-
-        let stride = self.width * 4;
-
-        Ok((self.width, self.height, stride, self.height * stride))
-    }
-
     /// Create a new pool and allocate `n` buffers in it
     ///
     /// The allocated buffers are stored in the buffer store
     pub fn allocate_buffers(
         &mut self,
-        event_queue: &EventQueue<Self>,
+        event_queue: &EventQueue<WaylandState>,
         n: i32,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (_, _, _, buffer_size) = self.calculate_buffer_dimensions()?;
@@ -146,26 +118,5 @@ impl WaylandState {
         println!("Allocated {} buffers: {} bytes", n, size);
 
         Ok(())
-    }
-}
-
-impl Dispatch<WlBuffer, i32> for WaylandState {
-    fn event(
-        state: &mut Self,
-        _proxy: &WlBuffer,
-        event: <WlBuffer as wayland_client::Proxy>::Event,
-        data: &i32,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        match event {
-            wl_buffer::Event::Release => {
-                // When a buffer is released, mark it as available for use in the store
-                if let Some(buffers) = state.buffers.as_mut() {
-                    buffers[*data as usize].in_use = false;
-                }
-            }
-            _ => {}
-        }
     }
 }

--- a/src/wayland/graphics/mod.rs
+++ b/src/wayland/graphics/mod.rs
@@ -1,3 +1,2 @@
-pub mod buffer;
 pub mod output;
 pub mod renderer;

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -1,3 +1,4 @@
+pub mod buffer;
 mod empty;
 pub mod event;
 pub mod graphics;

--- a/src/wayland/registry/registry.rs
+++ b/src/wayland/registry/registry.rs
@@ -43,7 +43,7 @@ impl Dispatch<WlRegistry, ()> for WaylandState {
                 }
                 "wl_shm" => {
                     let shm = registry.bind::<WlShm, _, _>(name, version, qh, ());
-                    state.shm = Some(shm);
+                    state.buffer_manager.set_shm(shm);
                 }
                 "wl_compositor" => {
                     let compositor = registry.bind::<WlCompositor, _, _>(name, version, qh, ());


### PR DESCRIPTION
Move buffer operations into a dedicated `BufferManager` structure.