### PR TITLE
refactor: use `Pipe` object to store file descriptor pairs

### DIFF
--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -40,7 +40,6 @@ extern "C"
 	int render(const QOpenGLFramebufferObject &fbo, void *buffer);
 
 	typedef void *(*RsGetBufferCallback)(void *user_data);
-	typedef void (*RsFrameReadyCallback)(void *user_data, void *buffer);
 
 	struct RsFrameRenderedEvent
 	{
@@ -52,7 +51,8 @@ extern "C"
 		const char *qmlPath;
 		int state;
 		void *renderer;
-		int rendererFd;
+		int rendererWriteFd;
+		int rendererReadFd;
 	};
 
 	struct QmlRenderer
@@ -132,7 +132,7 @@ extern "C"
 	void send_frame_rendered_event(QmlRenderer *renderer, void *buf)
 	{
 		frameRenderedEvent.buf = buf;
-		write_eventfd_notification(renderer->appState->rendererFd, &frameRenderedEvent);
+		write_eventfd_notification(renderer->appState->rendererWriteFd, &frameRenderedEvent);
 	}
 
 	void setup_renderer(QmlRenderer *renderer)

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -17,7 +17,7 @@ extern "C"
 
     QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath);
     int start_renderer(QmlRenderer *renderer);
-    void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer, RsFrameReadyCallback frameReady, void *userData);
+    void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer, void *userData);
     void cleanup_renderer(QmlRenderer *renderer);
 
 #ifdef __cplusplus

--- a/src/shared/interface.rs
+++ b/src/shared/interface.rs
@@ -38,11 +38,13 @@ macro_rules! safe_setter {
 }
 
 safe_getter!(get_state, state, State);
-safe_getter!(get_renderer_fd, renderer_fd, c_int);
+safe_setter!(get_renderer_read_fd, renderer_read_fd, c_int);
+safe_getter!(get_renderer_write_fd, renderer_write_fd, c_int);
 safe_getter!(get_renderer, renderer, *mut QmlRenderer);
 safe_getter!(get_qml_path, qml_path, *mut c_char);
 
 safe_setter!(set_state, state, State);
-safe_setter!(set_renderer_fd, renderer_fd, c_int);
+safe_setter!(set_renderer_read_fd, renderer_read_fd, c_int);
+safe_setter!(set_renderer_write_fd, renderer_write_fd, c_int);
 safe_setter!(set_renderer, renderer, *mut QmlRenderer);
 safe_setter!(set_qml_path, qml_path, *mut c_char);

--- a/src/shared/state.rs
+++ b/src/shared/state.rs
@@ -26,7 +26,8 @@ pub struct ApplicationState {
     pub qml_path: *mut c_char,
     pub state: State,
     pub renderer: *mut QmlRenderer,
-    pub renderer_fd: c_int,
+    pub renderer_write_fd: c_int,
+    pub renderer_read_fd: c_int,
 }
 
 impl ApplicationState {
@@ -35,7 +36,8 @@ impl ApplicationState {
             qml_path: qml_path,
             state: State::None,
             renderer: std::ptr::null_mut(),
-            renderer_fd: -1,
+            renderer_write_fd: -1,
+            renderer_read_fd: -1,
         }
     }
 }

--- a/src/wayland/event/event.rs
+++ b/src/wayland/event/event.rs
@@ -189,11 +189,10 @@ impl WaylandState {
         event_queue: &mut EventQueue<Self>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut event_loop = EventLoop::new(
-            self.renderer_read_fd
+            self.renderer_read_pipe
                 .as_ref()
-                .ok_or::<Box<dyn std::error::Error>>(
-                    "Renderer read file descriptor not set".into(),
-                )?
+                .ok_or("Renderer file descriptor not set")?
+                .read_fd()
                 .as_raw_fd(),
         )?;
 

--- a/src/wayland/graphics/renderer.rs
+++ b/src/wayland/graphics/renderer.rs
@@ -41,9 +41,10 @@ impl WaylandState {
     /// This event contains information about which buffer is ready to be displayed.
     fn read_renderer_event(&self) -> Result<RendererEvent, Box<dyn std::error::Error>> {
         let renderer_fd = self
-            .renderer_read_fd
+            .renderer_read_pipe
             .as_ref()
-            .ok_or("Renderer file descriptor not set")?;
+            .ok_or("Renderer file descriptor not set")?
+            .read_fd();
 
         let mut event_ptr = std::ptr::null_mut::<RendererEvent>();
         let bytes_read = unsafe {


### PR DESCRIPTION
This pull request contains the following changes:

- use `Pipe` objects store store file descriptor pairs
- remove an used function parameter from `render.hpp`