### PR TITLE
refactor: use `Event` for pipe communication instead of raw pointers

### DIFF
--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#pragma once
+
+#ifndef EVENT_HPP
+#define EVENT_HPP
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    enum class EventType : uint64_t
+    {
+        Wayland = 1,
+        Renderer = 2,
+    };
+
+    typedef uint64_t EventParam;
+
+    typedef struct
+    {
+        EventType event_type;
+        EventParam param_1;
+        EventParam param_2;
+    } Event;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -32,6 +32,8 @@
 #include <atomic>
 #include <chrono>
 
+#include "event.hpp"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/wayland/buffer/manager.rs
+++ b/src/wayland/buffer/manager.rs
@@ -6,7 +6,7 @@
         Provides the `BufferManager` structure for alloocating and using pixel buffers.
 */
 
-use crate::shared::ffi::RendererEvent;
+use crate::wayland::event::event::Event;
 use crate::wayland::state::WaylandState;
 use std::os::raw::c_void;
 use wayland_client::protocol::wl_buffer;
@@ -108,13 +108,13 @@ impl BufferManager {
     /// Searches for a `Buffer` matching the data provided by a `RendererEvent`
     pub fn find_buffer_from_event(
         &mut self,
-        event: &RendererEvent,
+        event: &Event,
     ) -> Result<&mut Buffer, Box<dyn std::error::Error>> {
         let buffers = self.buffers.as_mut().ok_or("Buffers unavailable")?;
 
         buffers
             .iter_mut()
-            .find(|b| b.data as *mut c_void == event.buffer)
+            .find(|b| b.data as *mut c_void == event.param_1.into())
             .ok_or("No matching buffer found".into())
     }
 }

--- a/src/wayland/event/event.rs
+++ b/src/wayland/event/event.rs
@@ -3,210 +3,46 @@
 
 /*
     event.rs:
-        Contains event loops that handle both Wayland events from an EventQueue
-        and from an EventFd, used for signals from the renderer, via epoll.
+        `Event` and `EventType` objects for event handling
 */
 
-use crate::shared::{interface::get_state, state::State};
-use crate::wayland::state::WaylandState;
-use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
-use std::os::fd::BorrowedFd;
-use std::os::fd::{AsRawFd, RawFd};
-use wayland_client::EventQueue;
-use wayland_client::backend::ReadEventsGuard;
+use crate::wayland::event::{event_param::EventParam, event_type::EventType};
 
-const WAYLAND_EVENT_TAG: u64 = 0;
-const RENDERER_EVENT_TAG: u64 = 1;
-
-/// Enum for event tags used in the `epoll` event loop
-enum EventType {
-    Wayland,
-    Renderer,
-    Unknown(u64),
-}
-
-impl From<u64> for EventType {
-    /// Return a new `EventType` object from a `u64`
-    ///
-    /// - A value of `0` corresponds to `EventType::Wayland`
-    /// - A value of `1` corresponds to `EventType::Renderer`
-    ///
-    /// Any other value corresponds to `EventType::Unknown(tag)`
-    fn from(tag: u64) -> Self {
-        match tag {
-            WAYLAND_EVENT_TAG => EventType::Wayland,
-            RENDERER_EVENT_TAG => EventType::Renderer,
-            other => EventType::Unknown(other),
-        }
-    }
-}
-
-/// Event loop structure to hold values used as part of the event loop
+/// Event structure containing event serial, type, and parameters
 ///
-/// Contains a `nix::sys::Epoll` object which can be waited on
-/// Contains an events array for processing
-/// Contains the renderer file descriptor, which is added to `Epoll`
-struct EventLoop {
-    epoll: Epoll,
-    events: [EpollEvent; 10],
-    renderer_fd: BorrowedFd<'static>,
+/// This structure is C-compatible, and is intended to be sent with a `Pipe`
+/// object.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct Event {
+    pub event_type: EventType,
+    pub param_1: EventParam,
+    pub param_2: EventParam,
 }
 
-impl EventLoop {
-    /// Create a new event loop given the raw renderer file descriptor
-    ///
-    /// The renderer file descriptor is added into `Epoll` automatically, and removed when dropping
-    fn new(renderer_fd: RawFd) -> Result<Self, Box<dyn std::error::Error>> {
-        let epoll = Epoll::new(EpollCreateFlags::empty())?;
-        let events = [EpollEvent::empty(); 10];
-        let renderer_fd = unsafe { BorrowedFd::borrow_raw(renderer_fd) };
-
-        let renderer_event = EpollEvent::new(EpollFlags::EPOLLIN, RENDERER_EVENT_TAG);
-        epoll.add(renderer_fd, renderer_event)?;
-
-        Ok(Self {
-            epoll,
-            events,
-            renderer_fd,
-        })
-    }
-}
-
-impl Drop for EventLoop {
-    fn drop(&mut self) {
-        let _ = self.epoll.delete(self.renderer_fd);
-    }
-}
-
-/// This guard structure is used to ensure the Wayland file descriptor (given by a `ReadEventsGuard` object).
-///
-/// This structure contains a reference to an `Epoll` object (probably from an `EventLoop`).
-/// The Wayland file descriptor is automatically removed from `Epoll` when dropped.
-struct WaylandFdCleanup<'a> {
-    epoll: &'a Epoll,
-    fd: BorrowedFd<'a>,
-}
-
-impl Drop for WaylandFdCleanup<'_> {
-    fn drop(&mut self) {
-        let _ = self.epoll.delete(self.fd);
-    }
-}
-
-impl WaylandState {
-    /// This function processes all events in the `events` array
-    ///
-    /// Returns a `bool` indicating whether any Wayland events were received, which need further processing
-    fn process_epoll_events(
-        &mut self,
-        events: &[EpollEvent],
-        num_events: usize,
-    ) -> Result<bool, Box<dyn std::error::Error>> {
-        let mut wayland_event_received = false;
-
-        for event in &events[..num_events] {
-            match EventType::from(event.data()) {
-                EventType::Wayland => {
-                    wayland_event_received = true;
-                }
-                EventType::Renderer => {
-                    self.handle_renderer_event()?;
-                }
-                EventType::Unknown(tag) => {
-                    println!("Received unknown event: {}", tag);
-                }
-            }
+impl Event {
+    /// Create a new event object of a specified type, with two parameters
+    pub fn new(event_type: EventType, param_1: EventParam, param_2: EventParam) -> Self {
+        Self {
+            event_type,
+            param_1,
+            param_2,
         }
-
-        Ok(wayland_event_received)
     }
 
-    /// This function reads and dispatches waiting Wayland events
+    /// Dereference a constant event pointer into an `Event`
     ///
-    /// The `ReadEventsGuard` object given to this function will be dropped
-    fn handle_wayland_events(
-        &mut self,
-        read_guard: ReadEventsGuard,
-        event_queue: &mut EventQueue<Self>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        read_guard.read()?;
-        event_queue.dispatch_pending(self)?;
-        Ok(())
+    /// This function handles raw pointers, thus, is unsafe.
+    /// This function is not responsible for proper pointer management.
+    pub unsafe fn from_ptr(ptr: *const Event) -> Self {
+        unsafe { std::ptr::read(ptr) }
     }
 
-    /// Wait for, and dispatch events using `epoll`
+    /// Dereference a mutable event pointer into an `Event`
     ///
-    /// This functions waits for Wayland and renderer events using `epoll`.
-    /// Upon receiving the events, they are dispatched to their relevant handlers via the `process_epoll_events` function.
-    fn dispatch_events(
-        &mut self,
-        event_loop: &mut EventLoop,
-        read_guard: ReadEventsGuard,
-        event_queue: &mut EventQueue<Self>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let wayland_fd = read_guard.connection_fd();
-        let wayland_event = EpollEvent::new(EpollFlags::EPOLLIN, WAYLAND_EVENT_TAG);
-
-        event_loop.epoll.add(wayland_fd, wayland_event)?;
-
-        // Use a scoped block here, so the Wayland file descriptor is dropped before moving `read_guard`
-        let wayland_event_received = {
-            // Ensure the Wayland file descriptor is cleaned up at the end of this block
-            let _cleanup_guard = WaylandFdCleanup {
-                epoll: &event_loop.epoll,
-                fd: wayland_fd,
-            };
-
-            let num_events = event_loop
-                .epoll
-                .wait(&mut event_loop.events, EpollTimeout::NONE)?;
-
-            self.process_epoll_events(&mut event_loop.events, num_events)?
-        };
-
-        if wayland_event_received {
-            self.handle_wayland_events(read_guard, event_queue)?;
-        } else {
-            // Explicitly drop the read guard to cancel the read
-            drop(read_guard);
-        }
-
-        Ok(())
-    }
-
-    /// This function returns a boolean value indicating whether the event loop should continue running
-    fn continue_running(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        Ok(get_state(self.app_state)
-            .ok_or::<Box<dyn std::error::Error>>("Failed to read app state".into())?
-            != State::Unlocked)
-    }
-
-    /// Run the event loop until exit
-    ///
-    /// This function initializes event loop state and triggers event reading via `epoll`.
-    pub fn run_event_loop(
-        &mut self,
-        event_queue: &mut EventQueue<Self>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut event_loop = EventLoop::new(
-            self.renderer_read_pipe
-                .as_ref()
-                .ok_or("Renderer file descriptor not set")?
-                .read_fd()
-                .as_raw_fd(),
-        )?;
-
-        while self.continue_running()? {
-            self.update_states(&event_queue)?;
-
-            event_queue.flush()?;
-            event_queue.dispatch_pending(self)?;
-
-            if let Some(read_guard) = event_queue.prepare_read() {
-                self.dispatch_events(&mut event_loop, read_guard, event_queue)?;
-            }
-        }
-
-        Ok(())
+    /// This function handles raw pointers, thus, is unsafe.
+    /// This function is not responsible for proper pointer management.
+    pub unsafe fn from_mut_ptr(ptr: *mut Event) -> Self {
+        unsafe { std::ptr::read(ptr) }
     }
 }

--- a/src/wayland/event/event_loop.rs
+++ b/src/wayland/event/event_loop.rs
@@ -8,38 +8,13 @@
 */
 
 use crate::shared::{interface::get_state, state::State};
+use crate::wayland::event::event_type::EventType;
 use crate::wayland::state::WaylandState;
 use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
 use std::os::fd::BorrowedFd;
 use std::os::fd::{AsRawFd, RawFd};
 use wayland_client::EventQueue;
 use wayland_client::backend::ReadEventsGuard;
-
-const WAYLAND_EVENT_TAG: u64 = 0;
-const RENDERER_EVENT_TAG: u64 = 1;
-
-/// Enum for event tags used in the `epoll` event loop
-enum EventType {
-    Wayland,
-    Renderer,
-    Unknown(u64),
-}
-
-impl From<u64> for EventType {
-    /// Return a new `EventType` object from a `u64`
-    ///
-    /// - A value of `0` corresponds to `EventType::Wayland`
-    /// - A value of `1` corresponds to `EventType::Renderer`
-    ///
-    /// Any other value corresponds to `EventType::Unknown(tag)`
-    fn from(tag: u64) -> Self {
-        match tag {
-            WAYLAND_EVENT_TAG => EventType::Wayland,
-            RENDERER_EVENT_TAG => EventType::Renderer,
-            other => EventType::Unknown(other),
-        }
-    }
-}
 
 /// Event loop structure to hold values used as part of the event loop
 ///
@@ -61,7 +36,7 @@ impl EventLoop {
         let events = [EpollEvent::empty(); 10];
         let renderer_fd = unsafe { BorrowedFd::borrow_raw(renderer_fd) };
 
-        let renderer_event = EpollEvent::new(EpollFlags::EPOLLIN, RENDERER_EVENT_TAG);
+        let renderer_event = EpollEvent::new(EpollFlags::EPOLLIN, EventType::Renderer as u64);
         epoll.add(renderer_fd, renderer_event)?;
 
         Ok(Self {
@@ -105,15 +80,12 @@ impl WaylandState {
         let mut wayland_event_received = false;
 
         for event in &events[..num_events] {
-            match EventType::from(event.data()) {
+            match EventType::try_from(event.data())? {
                 EventType::Wayland => {
                     wayland_event_received = true;
                 }
                 EventType::Renderer => {
                     self.handle_renderer_event()?;
-                }
-                EventType::Unknown(tag) => {
-                    println!("Received unknown event: {}", tag);
                 }
             }
         }
@@ -145,7 +117,7 @@ impl WaylandState {
         event_queue: &mut EventQueue<Self>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let wayland_fd = read_guard.connection_fd();
-        let wayland_event = EpollEvent::new(EpollFlags::EPOLLIN, WAYLAND_EVENT_TAG);
+        let wayland_event = EpollEvent::new(EpollFlags::EPOLLIN, EventType::Wayland as u64);
 
         event_loop.epoll.add(wayland_fd, wayland_event)?;
 

--- a/src/wayland/event/event_loop.rs
+++ b/src/wayland/event/event_loop.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    event.rs:
+        Contains event loops that handle both Wayland events from an EventQueue
+        and from an EventFd, used for signals from the renderer, via epoll.
+*/
+
+use crate::shared::{interface::get_state, state::State};
+use crate::wayland::state::WaylandState;
+use nix::sys::epoll::{Epoll, EpollCreateFlags, EpollEvent, EpollFlags, EpollTimeout};
+use std::os::fd::BorrowedFd;
+use std::os::fd::{AsRawFd, RawFd};
+use wayland_client::EventQueue;
+use wayland_client::backend::ReadEventsGuard;
+
+const WAYLAND_EVENT_TAG: u64 = 0;
+const RENDERER_EVENT_TAG: u64 = 1;
+
+/// Enum for event tags used in the `epoll` event loop
+enum EventType {
+    Wayland,
+    Renderer,
+    Unknown(u64),
+}
+
+impl From<u64> for EventType {
+    /// Return a new `EventType` object from a `u64`
+    ///
+    /// - A value of `0` corresponds to `EventType::Wayland`
+    /// - A value of `1` corresponds to `EventType::Renderer`
+    ///
+    /// Any other value corresponds to `EventType::Unknown(tag)`
+    fn from(tag: u64) -> Self {
+        match tag {
+            WAYLAND_EVENT_TAG => EventType::Wayland,
+            RENDERER_EVENT_TAG => EventType::Renderer,
+            other => EventType::Unknown(other),
+        }
+    }
+}
+
+/// Event loop structure to hold values used as part of the event loop
+///
+/// Contains a `nix::sys::Epoll` object which can be waited on
+/// Contains an events array for processing
+/// Contains the renderer file descriptor, which is added to `Epoll`
+struct EventLoop {
+    epoll: Epoll,
+    events: [EpollEvent; 10],
+    renderer_fd: BorrowedFd<'static>,
+}
+
+impl EventLoop {
+    /// Create a new event loop given the raw renderer file descriptor
+    ///
+    /// The renderer file descriptor is added into `Epoll` automatically, and removed when dropping
+    fn new(renderer_fd: RawFd) -> Result<Self, Box<dyn std::error::Error>> {
+        let epoll = Epoll::new(EpollCreateFlags::empty())?;
+        let events = [EpollEvent::empty(); 10];
+        let renderer_fd = unsafe { BorrowedFd::borrow_raw(renderer_fd) };
+
+        let renderer_event = EpollEvent::new(EpollFlags::EPOLLIN, RENDERER_EVENT_TAG);
+        epoll.add(renderer_fd, renderer_event)?;
+
+        Ok(Self {
+            epoll,
+            events,
+            renderer_fd,
+        })
+    }
+}
+
+impl Drop for EventLoop {
+    fn drop(&mut self) {
+        let _ = self.epoll.delete(self.renderer_fd);
+    }
+}
+
+/// This guard structure is used to ensure the Wayland file descriptor (given by a `ReadEventsGuard` object).
+///
+/// This structure contains a reference to an `Epoll` object (probably from an `EventLoop`).
+/// The Wayland file descriptor is automatically removed from `Epoll` when dropped.
+struct WaylandFdCleanup<'a> {
+    epoll: &'a Epoll,
+    fd: BorrowedFd<'a>,
+}
+
+impl Drop for WaylandFdCleanup<'_> {
+    fn drop(&mut self) {
+        let _ = self.epoll.delete(self.fd);
+    }
+}
+
+impl WaylandState {
+    /// This function processes all events in the `events` array
+    ///
+    /// Returns a `bool` indicating whether any Wayland events were received, which need further processing
+    fn process_epoll_events(
+        &mut self,
+        events: &[EpollEvent],
+        num_events: usize,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let mut wayland_event_received = false;
+
+        for event in &events[..num_events] {
+            match EventType::from(event.data()) {
+                EventType::Wayland => {
+                    wayland_event_received = true;
+                }
+                EventType::Renderer => {
+                    self.handle_renderer_event()?;
+                }
+                EventType::Unknown(tag) => {
+                    println!("Received unknown event: {}", tag);
+                }
+            }
+        }
+
+        Ok(wayland_event_received)
+    }
+
+    /// This function reads and dispatches waiting Wayland events
+    ///
+    /// The `ReadEventsGuard` object given to this function will be dropped
+    fn handle_wayland_events(
+        &mut self,
+        read_guard: ReadEventsGuard,
+        event_queue: &mut EventQueue<Self>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        read_guard.read()?;
+        event_queue.dispatch_pending(self)?;
+        Ok(())
+    }
+
+    /// Wait for, and dispatch events using `epoll`
+    ///
+    /// This functions waits for Wayland and renderer events using `epoll`.
+    /// Upon receiving the events, they are dispatched to their relevant handlers via the `process_epoll_events` function.
+    fn dispatch_events(
+        &mut self,
+        event_loop: &mut EventLoop,
+        read_guard: ReadEventsGuard,
+        event_queue: &mut EventQueue<Self>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let wayland_fd = read_guard.connection_fd();
+        let wayland_event = EpollEvent::new(EpollFlags::EPOLLIN, WAYLAND_EVENT_TAG);
+
+        event_loop.epoll.add(wayland_fd, wayland_event)?;
+
+        // Use a scoped block here, so the Wayland file descriptor is dropped before moving `read_guard`
+        let wayland_event_received = {
+            // Ensure the Wayland file descriptor is cleaned up at the end of this block
+            let _cleanup_guard = WaylandFdCleanup {
+                epoll: &event_loop.epoll,
+                fd: wayland_fd,
+            };
+
+            let num_events = event_loop
+                .epoll
+                .wait(&mut event_loop.events, EpollTimeout::NONE)?;
+
+            self.process_epoll_events(&mut event_loop.events, num_events)?
+        };
+
+        if wayland_event_received {
+            self.handle_wayland_events(read_guard, event_queue)?;
+        } else {
+            // Explicitly drop the read guard to cancel the read
+            drop(read_guard);
+        }
+
+        Ok(())
+    }
+
+    /// This function returns a boolean value indicating whether the event loop should continue running
+    fn continue_running(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        Ok(get_state(self.app_state)
+            .ok_or::<Box<dyn std::error::Error>>("Failed to read app state".into())?
+            != State::Unlocked)
+    }
+
+    /// Run the event loop until exit
+    ///
+    /// This function initializes event loop state and triggers event reading via `epoll`.
+    pub fn run_event_loop(
+        &mut self,
+        event_queue: &mut EventQueue<Self>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut event_loop = EventLoop::new(
+            self.renderer_read_pipe
+                .as_ref()
+                .ok_or("Renderer file descriptor not set")?
+                .read_fd()
+                .as_raw_fd(),
+        )?;
+
+        while self.continue_running()? {
+            self.update_states(&event_queue)?;
+
+            event_queue.flush()?;
+            event_queue.dispatch_pending(self)?;
+
+            if let Some(read_guard) = event_queue.prepare_read() {
+                self.dispatch_events(&mut event_loop, read_guard, event_queue)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/wayland/event/event_param.rs
+++ b/src/wayland/event/event_param.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    event_param.rs:
+        Event parameter structure and conversions
+*/
+
+use std::os::raw::c_void;
+
+/// Structure for holding parameters for `Event` objects
+///
+/// This structure is fully C-compatible.
+///
+/// This structure stores a single `u64` which can be converted to other
+/// types using the `From<EventParam>` trait.
+#[derive(Debug, Clone, Copy)]
+pub struct EventParam(u64);
+
+impl EventParam {
+    /// Returns a new `EventType` from a value
+    ///
+    /// The type of this value must implement the `From` trait for `EventParam`
+    pub fn new<T: Into<EventParam>>(value: T) -> Self {
+        value.into()
+    }
+
+    /// Return the currently held value as type `T`
+    ///
+    /// Type `T` must have the trait `From<EventParam>` implemented.
+    pub fn as_<T: From<EventParam>>(self) -> T {
+        T::from(self)
+    }
+
+    /// Return the raw `u64` held by this object
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+}
+
+/*
+    Conversions to/from `EventParam` and other types
+*/
+
+impl From<EventParam> for *mut c_void {
+    fn from(param: EventParam) -> Self {
+        param.0 as *mut c_void
+    }
+}
+
+impl From<*mut c_void> for EventParam {
+    fn from(ptr: *mut c_void) -> Self {
+        EventParam(ptr as u64)
+    }
+}
+
+impl From<*const c_void> for EventParam {
+    fn from(ptr: *const c_void) -> Self {
+        EventParam(ptr as u64)
+    }
+}

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -16,11 +16,11 @@ pub enum EventType {
     Renderer = 2,
 }
 
-impl TryFrom<u32> for EventType {
+impl TryFrom<u64> for EventType {
     type Error = &'static str;
 
     /// Create an `EventType` from an event tag value
-    fn try_from(tag: u32) -> Result<Self, Self::Error> {
+    fn try_from(tag: u64) -> Result<Self, Self::Error> {
         match tag {
             1 => Ok(EventType::Wayland),
             2 => Ok(EventType::Renderer),

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -1,4 +1,12 @@
-/// The type of event that is being handled
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    event_type.rs:
+        This file contains the `EventType` enum and conversions
+*/
+
+// The type of event that is being handled
 ///
 /// This enum is C-compatible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -1,0 +1,22 @@
+/// The type of event that is being handled
+///
+/// This enum is C-compatible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u64)]
+pub enum EventType {
+    Wayland = 1,
+    Renderer = 2,
+}
+
+impl TryFrom<u32> for EventType {
+    type Error = &'static str;
+
+    /// Create an `EventType` from an event tag value
+    fn try_from(tag: u32) -> Result<Self, Self::Error> {
+        match tag {
+            1 => Ok(EventType::Wayland),
+            2 => Ok(EventType::Renderer),
+            _ => Err("Invalid EventType tag"),
+        }
+    }
+}

--- a/src/wayland/event/mod.rs
+++ b/src/wayland/event/mod.rs
@@ -1,1 +1,4 @@
 pub mod event;
+pub mod event_loop;
+pub mod event_param;
+pub mod event_type;


### PR DESCRIPTION
Use a new `Event` structure for pipe communication, to avoid using raw pointers.

- add `Event` structure for a single pipe message
- add `EventType` to identify event sources/destinations
- add `EventParam` based on `u64` for event parameters