### PR TITLE
Define formatting rules for C++ source files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+AlwaysAddBraces: true
+IndentWidth: 4

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -9,24 +9,21 @@
 #include <cstdint>
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-    enum class EventType : uint64_t
-    {
-        Wayland = 1,
-        Renderer = 2,
-    };
+enum class EventType : uint64_t {
+    Wayland = 1,
+    Renderer = 2,
+};
 
-    typedef uint64_t EventParam;
+typedef uint64_t EventParam;
 
-    typedef struct
-    {
-        EventType event_type;
-        EventParam param_1;
-        EventParam param_2;
-    } Event;
+typedef struct {
+    EventType event_type;
+    EventParam param_1;
+    EventParam param_2;
+} Event;
 
 #ifdef __cplusplus
 }

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -2,10 +2,11 @@
 // Copyright (C) 2025, Nathan Gill
 
 /*
-	render.cpp:
-		This file contains the QML rendering logic.
+        render.cpp:
+                This file contains the QML rendering logic.
 */
 
+#include <QDebug>
 #include <QGuiApplication>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
@@ -17,353 +18,351 @@
 #include <QQuickRenderTarget>
 #include <QQuickWindow>
 #include <QSurfaceFormat>
-#include <QDebug>
-#include <QVariant>
 #include <QTimer>
+#include <QVariant>
 
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 
-#include <iostream>
-#include <unistd.h>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <unistd.h>
 
 #include "event.hpp"
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-	int render(const QOpenGLFramebufferObject &fbo, void *buffer);
+int render(const QOpenGLFramebufferObject &fbo, void *buffer);
 
-	typedef void *(*RsGetBufferCallback)(void *user_data);
+typedef void *(*RsGetBufferCallback)(void *user_data);
 
-	struct ApplicationState
-	{
-		const char *qmlPath;
-		int state;
-		void *renderer;
-		int rendererWriteFd;
-		int rendererReadFd;
-	};
+struct ApplicationState {
+    const char *qmlPath;
+    int state;
+    void *renderer;
+    int rendererWriteFd;
+    int rendererReadFd;
+};
 
-	struct QmlRenderer
-	{
-		QGuiApplication *app;
-		QSize fbSize;
-		QOpenGLContext *context;
-		QSurfaceFormat *surfaceFormat;
-		QOffscreenSurface *surface;
-		QQuickRenderControl *renderControl;
-		QQuickWindow *window;
-		QOpenGLFramebufferObjectFormat *fbFormat;
-		QOpenGLFramebufferObject *fb;
-		QQmlEngine *engine;
-		QQmlComponent *component;
+struct QmlRenderer {
+    QGuiApplication *app;
+    QSize fbSize;
+    QOpenGLContext *context;
+    QSurfaceFormat *surfaceFormat;
+    QOffscreenSurface *surface;
+    QQuickRenderControl *renderControl;
+    QQuickWindow *window;
+    QOpenGLFramebufferObjectFormat *fbFormat;
+    QOpenGLFramebufferObject *fb;
+    QQmlEngine *engine;
+    QQmlComponent *component;
 
-		const char *qmlPath;
-		bool running = false;
+    const char *qmlPath;
+    bool running = false;
 
-		RsGetBufferCallback getBufferCallback = nullptr;
-		void *userData = nullptr;
+    RsGetBufferCallback getBufferCallback = nullptr;
+    void *userData = nullptr;
 
-		std::thread renderThread;
-		std::atomic<bool> threadRunning{false};
-		std::atomic<bool> shouldStop{false};
-		std::mutex initMutex;
-		std::condition_variable initCondition;
-		std::atomic<bool> initialized{false};
+    std::thread renderThread;
+    std::atomic<bool> threadRunning{false};
+    std::atomic<bool> shouldStop{false};
+    std::mutex initMutex;
+    std::condition_variable initCondition;
+    std::atomic<bool> initialized{false};
 
-		ApplicationState *appState;
-	};
+    ApplicationState *appState;
+};
 
-	QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath, ApplicationState *appState)
-	{
-		QmlRenderer *renderer = new QmlRenderer();
-		renderer->fbSize = QSize(width, height);
-		renderer->qmlPath = qmlPath;
-		renderer->appState = appState;
+QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath,
+                                 ApplicationState *appState) {
+    QmlRenderer *renderer = new QmlRenderer();
+    renderer->fbSize = QSize(width, height);
+    renderer->qmlPath = qmlPath;
+    renderer->appState = appState;
 
-		return renderer;
-	}
+    return renderer;
+}
 
-	void set_deinitialize(QmlRenderer *renderer)
-	{
-		{
-			std::lock_guard<std::mutex> lock(renderer->initMutex);
-			renderer->initialized = false;
-		}
-		renderer->initCondition.notify_one();
-	}
+void set_deinitialize(QmlRenderer *renderer) {
+    {
+        std::lock_guard<std::mutex> lock(renderer->initMutex);
+        renderer->initialized = false;
+    }
+    renderer->initCondition.notify_one();
+}
 
-	void set_initialize(QmlRenderer *renderer)
-	{
-		{
-			std::lock_guard<std::mutex> lock(renderer->initMutex);
-			renderer->initialized = true;
-		}
-		renderer->initCondition.notify_one();
-	}
+void set_initialize(QmlRenderer *renderer) {
+    {
+        std::lock_guard<std::mutex> lock(renderer->initMutex);
+        renderer->initialized = true;
+    }
+    renderer->initCondition.notify_one();
+}
 
-	int write_event(int fd, EventParam param_1, EventParam param_2)
-	{
-		Event ev = {
-			EventType::Renderer,
-			param_1,
-			param_2,
-		};
+int write_event(int fd, EventParam param_1, EventParam param_2) {
+    Event ev = {
+        EventType::Renderer,
+        param_1,
+        param_2,
+    };
 
-		ssize_t res = write(fd, &ev, sizeof(Event));
-		if (res != sizeof(Event))
-		{
-			std::cerr << "Failed to write event\n";
-			return -1;
-		}
+    ssize_t res = write(fd, &ev, sizeof(Event));
+    if (res != sizeof(Event)) {
+        std::cerr << "Failed to write event\n";
+        return -1;
+    }
 
-		return 0;
-	}
+    return 0;
+}
 
-	void send_frame_rendered_event(QmlRenderer *renderer, void *buf)
-	{
-		write_event(renderer->appState->rendererWriteFd, reinterpret_cast<EventParam>(buf), 0);
-	}
+void send_frame_rendered_event(QmlRenderer *renderer, void *buf) {
+    write_event(renderer->appState->rendererWriteFd,
+                reinterpret_cast<EventParam>(buf), 0);
+}
 
-	void setup_renderer(QmlRenderer *renderer)
-	{
-		int argc = 0;
-		char **argv = nullptr;
-		renderer->app = new QGuiApplication(argc, argv);
+void setup_renderer(QmlRenderer *renderer) {
+    int argc = 0;
+    char **argv = nullptr;
+    renderer->app = new QGuiApplication(argc, argv);
 
-		renderer->context = new QOpenGLContext();
-		renderer->surfaceFormat = new QSurfaceFormat();
+    renderer->context = new QOpenGLContext();
+    renderer->surfaceFormat = new QSurfaceFormat();
 
-		renderer->surfaceFormat->setDepthBufferSize(24);
-		renderer->surfaceFormat->setStencilBufferSize(8);
-		renderer->surfaceFormat->setVersion(3, 2);
-		renderer->surfaceFormat->setProfile(QSurfaceFormat::CoreProfile);
-		renderer->context->setFormat(*renderer->surfaceFormat);
+    renderer->surfaceFormat->setDepthBufferSize(24);
+    renderer->surfaceFormat->setStencilBufferSize(8);
+    renderer->surfaceFormat->setVersion(3, 2);
+    renderer->surfaceFormat->setProfile(QSurfaceFormat::CoreProfile);
+    renderer->context->setFormat(*renderer->surfaceFormat);
 
-		if (!renderer->context->create())
-		{
-			std::cerr << "Failed to create OpenGL context\n";
-			set_deinitialize(renderer);
-			return;
-		}
+    if (!renderer->context->create()) {
+        std::cerr << "Failed to create OpenGL context\n";
+        set_deinitialize(renderer);
+        return;
+    }
 
-		renderer->surface = new QOffscreenSurface();
-		renderer->surface->setFormat(renderer->context->format());
-		renderer->surface->create();
+    renderer->surface = new QOffscreenSurface();
+    renderer->surface->setFormat(renderer->context->format());
+    renderer->surface->create();
 
-		if (!renderer->surface->isValid())
-		{
-			std::cerr << "Failed to create offscreen surface\n";
-			set_deinitialize(renderer);
-			return;
-		}
+    if (!renderer->surface->isValid()) {
+        std::cerr << "Failed to create offscreen surface\n";
+        set_deinitialize(renderer);
+        return;
+    }
 
-		if (!renderer->context->makeCurrent(renderer->surface))
-		{
-			std::cerr << "Failed to make OpenGL context current\n";
-			set_deinitialize(renderer);
-			return;
-		}
+    if (!renderer->context->makeCurrent(renderer->surface)) {
+        std::cerr << "Failed to make OpenGL context current\n";
+        set_deinitialize(renderer);
+        return;
+    }
 
-		renderer->renderControl = new QQuickRenderControl();
-		renderer->window = new QQuickWindow(renderer->renderControl);
-		renderer->window->resize(renderer->fbSize);
+    renderer->renderControl = new QQuickRenderControl();
+    renderer->window = new QQuickWindow(renderer->renderControl);
+    renderer->window->resize(renderer->fbSize);
 
-		if (!renderer->renderControl->initialize())
-		{
-			std::cerr << "Failed to initialize render control\n";
-			set_deinitialize(renderer);
-			return;
-		}
+    if (!renderer->renderControl->initialize()) {
+        std::cerr << "Failed to initialize render control\n";
+        set_deinitialize(renderer);
+        return;
+    }
 
-		renderer->fbFormat = new QOpenGLFramebufferObjectFormat();
-		renderer->fbFormat->setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
-		renderer->fb = new QOpenGLFramebufferObject(renderer->fbSize, *renderer->fbFormat);
+    renderer->fbFormat = new QOpenGLFramebufferObjectFormat();
+    renderer->fbFormat->setAttachment(
+        QOpenGLFramebufferObject::CombinedDepthStencil);
+    renderer->fb =
+        new QOpenGLFramebufferObject(renderer->fbSize, *renderer->fbFormat);
 
-		auto renderTarget = QQuickRenderTarget::fromOpenGLTexture(renderer->fb->texture(), renderer->fb->size());
-		renderer->window->setRenderTarget(renderTarget);
+    auto renderTarget = QQuickRenderTarget::fromOpenGLTexture(
+        renderer->fb->texture(), renderer->fb->size());
+    renderer->window->setRenderTarget(renderTarget);
 
-		renderer->engine = new QQmlEngine();
-		renderer->component = new QQmlComponent(renderer->engine);
-	}
+    renderer->engine = new QQmlEngine();
+    renderer->component = new QQmlComponent(renderer->engine);
+}
 
-	void setup_renderer_signals(QmlRenderer *renderer)
-	{
-		QObject::connect(renderer->component, &QQmlComponent::statusChanged, [renderer]()
-						 {
-			if (renderer->component->status() == QQmlComponent::Ready) {
-				QObject *rootObject = renderer->component->create();
-				if (!rootObject) {
-					std::cerr << "Failed to create QML root object\n";
-					return;
-				}
+void setup_renderer_signals(QmlRenderer *renderer) {
+    QObject::connect(
+        renderer->component, &QQmlComponent::statusChanged, [renderer]() {
+            if (renderer->component->status() == QQmlComponent::Ready) {
+                QObject *rootObject = renderer->component->create();
+                if (!rootObject) {
+                    std::cerr << "Failed to create QML root object\n";
+                    return;
+                }
 
-				QQuickItem *rootItem = qobject_cast<QQuickItem *>(rootObject);
-				if (!rootItem) {
-					std::cerr << "Root object is not a QQuickItem\n";
-					delete rootObject;
-					return;
-				}
+                QQuickItem *rootItem = qobject_cast<QQuickItem *>(rootObject);
+                if (!rootItem) {
+                    std::cerr << "Root object is not a QQuickItem\n";
+                    delete rootObject;
+                    return;
+                }
 
-				rootItem->setParentItem(renderer->window->contentItem());
-				rootItem->setWidth(renderer->fbSize.width());
-				rootItem->setHeight(renderer->fbSize.height());
+                rootItem->setParentItem(renderer->window->contentItem());
+                rootItem->setWidth(renderer->fbSize.width());
+                rootItem->setHeight(renderer->fbSize.height());
 
-				renderer->running = true;
-			} else if (renderer->component->status() == QQmlComponent::Error) {
-				std::cerr << "QML Component has errors:" << std::endl;
-				const auto errors = renderer->component->errors();
-				for (const auto &error : errors)
-					std::cerr << "  " << error.toString().toStdString() << std::endl;
-			} });
+                renderer->running = true;
+            } else if (renderer->component->status() == QQmlComponent::Error) {
+                std::cerr << "QML Component has errors:" << std::endl;
+                const auto errors = renderer->component->errors();
+                for (const auto &error : errors) {
+                    std::cerr << "  " << error.toString().toStdString()
+                              << std::endl;
+                }
+            }
+        });
 
-		QObject::connect(renderer->renderControl, &QQuickRenderControl::renderRequested, [renderer]()
-						 {
-			if (!renderer->running || !renderer->fb->isValid() || renderer->shouldStop)
-				return;
-				
-			if (!renderer->context->makeCurrent(renderer->surface)) {
-				std::cerr << "Failed to make OpenGL context current\n";
-				return;
-			}       
+    QObject::connect(
+        renderer->renderControl, &QQuickRenderControl::renderRequested,
+        [renderer]() {
+            if (!renderer->running || !renderer->fb->isValid() ||
+                renderer->shouldStop)
+                return;
 
-			renderer->renderControl->polishItems();
-			renderer->renderControl->beginFrame();
-			renderer->renderControl->sync();
-			renderer->renderControl->render();
-			renderer->renderControl->endFrame();
-			
-			if (renderer->getBufferCallback) {
-				void* buffer = renderer->getBufferCallback(renderer->userData);
-				if (buffer) {
-					render(*renderer->fb, buffer);
-					send_frame_rendered_event(renderer, buffer);
-				}
-			} });
+            if (!renderer->context->makeCurrent(renderer->surface)) {
+                std::cerr << "Failed to make OpenGL context current\n";
+                return;
+            }
 
-		QObject::connect(renderer->renderControl, &QQuickRenderControl::sceneChanged, [renderer]()
-						 { QMetaObject::invokeMethod(renderer->window, [renderer]()
-													 { renderer->window->update(); }, Qt::QueuedConnection); });
+            renderer->renderControl->polishItems();
+            renderer->renderControl->beginFrame();
+            renderer->renderControl->sync();
+            renderer->renderControl->render();
+            renderer->renderControl->endFrame();
 
-		QObject::connect(renderer->app, &QGuiApplication::aboutToQuit, [renderer]()
-						 {
-			renderer->running = false;
-			renderer->renderControl->disconnect(); });
-	}
+            if (renderer->getBufferCallback) {
+                void *buffer = renderer->getBufferCallback(renderer->userData);
+                if (buffer) {
+                    render(*renderer->fb, buffer);
+                    send_frame_rendered_event(renderer, buffer);
+                }
+            }
+        });
 
-	void qml_renderer_thread(QmlRenderer *renderer)
-	{
-		QGuiApplication::setAttribute(Qt::AA_UseOpenGLES, false);
+    QObject::connect(renderer->renderControl,
+                     &QQuickRenderControl::sceneChanged, [renderer]() {
+                         QMetaObject::invokeMethod(
+                             renderer->window,
+                             [renderer]() { renderer->window->update(); },
+                             Qt::QueuedConnection);
+                     });
 
-		setup_renderer(renderer);
-		setup_renderer_signals(renderer);
-		set_initialize(renderer);
+    QObject::connect(renderer->app, &QGuiApplication::aboutToQuit,
+                     [renderer]() {
+                         renderer->running = false;
+                         renderer->renderControl->disconnect();
+                     });
+}
 
-		renderer->threadRunning = true;
-		while (!renderer->shouldStop && renderer->app)
-		{
-			renderer->app->processEvents(QEventLoop::AllEvents, 16);
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		}
+void qml_renderer_thread(QmlRenderer *renderer) {
+    QGuiApplication::setAttribute(Qt::AA_UseOpenGLES, false);
 
-		renderer->threadRunning = false;
-	}
+    setup_renderer(renderer);
+    setup_renderer_signals(renderer);
+    set_initialize(renderer);
 
-	int start_renderer(QmlRenderer *renderer)
-	{
-		if (!renderer)
-		{
-			std::cerr << "Invalid renderer\n";
-			return -1;
-		}
+    renderer->threadRunning = true;
+    while (!renderer->shouldStop && renderer->app) {
+        renderer->app->processEvents(QEventLoop::AllEvents, 16);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 
-		renderer->renderThread = std::thread(qml_renderer_thread, renderer);
+    renderer->threadRunning = false;
+}
 
-		std::unique_lock<std::mutex> lock(renderer->initMutex);
-		renderer->initCondition.wait(lock, [renderer]
-									 { return renderer->initialized.load(); });
+int start_renderer(QmlRenderer *renderer) {
+    if (!renderer) {
+        std::cerr << "Invalid renderer\n";
+        return -1;
+    }
 
-		if (!renderer->initialized)
-		{
-			std::cerr << "Failed to initialize Qt\n";
-			return -1;
-		}
+    renderer->renderThread = std::thread(qml_renderer_thread, renderer);
 
-		QMetaObject::invokeMethod(renderer->component, [renderer]()
-								  {
-			std::cout << "Loading QML component..." << std::endl;
-			renderer->component->loadUrl(QUrl::fromLocalFile(renderer->qmlPath)); }, Qt::QueuedConnection);
+    std::unique_lock<std::mutex> lock(renderer->initMutex);
+    renderer->initCondition.wait(
+        lock, [renderer] { return renderer->initialized.load(); });
 
-		return 0;
-	}
+    if (!renderer->initialized) {
+        std::cerr << "Failed to initialize Qt\n";
+        return -1;
+    }
 
-	void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer, void *userData)
-	{
-		if (!renderer)
-			return;
+    QMetaObject::invokeMethod(
+        renderer->component,
+        [renderer]() {
+            std::cout << "Loading QML component..." << std::endl;
+            renderer->component->loadUrl(
+                QUrl::fromLocalFile(renderer->qmlPath));
+        },
+        Qt::QueuedConnection);
 
-		renderer->getBufferCallback = getBuffer;
-		renderer->userData = userData;
-	}
+    return 0;
+}
 
-	void cleanup_renderer(QmlRenderer *renderer)
-	{
-		if (!renderer)
-			return;
+void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer,
+                   void *userData) {
+    if (!renderer) {
+        return;
+    }
 
-		renderer->shouldStop = true;
-		renderer->running = false;
+    renderer->getBufferCallback = getBuffer;
+    renderer->userData = userData;
+}
 
-		if (renderer->renderThread.joinable())
-		{
-			renderer->renderThread.join();
-		}
+void cleanup_renderer(QmlRenderer *renderer) {
+    if (!renderer) {
+        return;
+    }
 
-		delete renderer;
-	}
+    renderer->shouldStop = true;
+    renderer->running = false;
 
-	int render(const QOpenGLFramebufferObject &fbo, void *buffer)
-	{
-		int width = fbo.width();
-		int height = fbo.height();
+    if (renderer->renderThread.joinable()) {
+        renderer->renderThread.join();
+    }
 
-		glBindFramebuffer(GL_FRAMEBUFFER, fbo.handle());
+    delete renderer;
+}
 
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE)
-		{
-			std::cerr << "Original framebuffer incomplete: 0x" << std::hex << status << "\n";
-			return 1;
-		}
+int render(const QOpenGLFramebufferObject &fbo, void *buffer) {
+    int width = fbo.width();
+    int height = fbo.height();
 
-		unsigned char *outputBuffer = static_cast<unsigned char *>(buffer);
-		int rowSize = width * 4;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo.handle());
 
-		// Read the framebuffer, starting at the bottom
-		for (int y = 0; y < height; y++)
-		{
-			glReadPixels(0, height - 1 - y, width, 1, GL_BGRA, GL_UNSIGNED_BYTE, outputBuffer + y * rowSize);
-		}
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        std::cerr << "Original framebuffer incomplete: 0x" << std::hex << status
+                  << "\n";
+        return 1;
+    }
 
-		GLenum error = glGetError();
-		if (error != GL_NO_ERROR)
-		{
-			std::cerr << "glReadPixels failed with error: 0x" << std::hex << error << std::endl;
-			return 1;
-		}
+    unsigned char *outputBuffer = static_cast<unsigned char *>(buffer);
+    int rowSize = width * 4;
 
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    // Read the framebuffer, starting at the bottom
+    for (int y = 0; y < height; y++) {
+        glReadPixels(0, height - 1 - y, width, 1, GL_BGRA, GL_UNSIGNED_BYTE,
+                     outputBuffer + y * rowSize);
+    }
 
-		return 0;
-	}
+    GLenum error = glGetError();
+    if (error != GL_NO_ERROR) {
+        std::cerr << "glReadPixels failed with error: 0x" << std::hex << error
+                  << std::endl;
+        return 1;
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    return 0;
+}
 
 #ifdef __cplusplus
 }

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -7,18 +7,18 @@
 #define RENDER_HPP
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
-    struct QmlRenderer;
+struct QmlRenderer;
 
-    typedef void *(*RsGetBufferCallback)(void *user_data);
+typedef void *(*RsGetBufferCallback)(void *user_data);
 
-    QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath);
-    int start_renderer(QmlRenderer *renderer);
-    void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer, void *userData);
-    void cleanup_renderer(QmlRenderer *renderer);
+QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath);
+int start_renderer(QmlRenderer *renderer);
+void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer,
+                   void *userData);
+void cleanup_renderer(QmlRenderer *renderer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Define formatting rules for C++ source files using a `.clang-format` file.
The format is based on the built-in LLVM style, but with 4-space indents, and braces for single statements.