### PR TITLE
feat: send Wayland keyboard events to Qt

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,5 @@
 BasedOnStyle: LLVM
 AlwaysAddBraces: true
+AccessModifierOffset: -4
+IndentCaseLabels: true
 IndentWidth: 4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -45,7 +45,7 @@ jobs:
                   sudo apt update
                   sudo apt install -y \
                     qt6-base-dev qt6-declarative-dev qt6-tools-dev \
-                    qt6-base-dev-tools libgl1-mesa-dev
+                    qt6-base-dev-tools libgl1-mesa-dev libxkbcommon-dev
 
             - name: Configure environment
               run: echo "QT6_PREFIX=$(qtpaths6 --install-prefix)" >> $GITHUB_ENV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,51 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,12 +25,6 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -90,67 +39,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -163,111 +55,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "indexmap"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "libredox"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -276,86 +67,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "logos"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
-dependencies = [
- "beef",
- "fnv",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex-syntax",
- "syn",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
-dependencies = [
- "logos-codegen",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
 
 [[package]]
 name = "nix"
@@ -365,114 +80,15 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
 ]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
- "unicase",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
- "unicase",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -502,70 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,37 +131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
@@ -618,138 +143,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tlockr"
 version = "0.1.0"
 dependencies = [
  "cmake",
- "memmap2",
- "nix 0.30.1",
+ "nix",
  "wayland-client",
  "wayland-protocols",
- "xkbcommon-rs",
 ]
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wayland-backend"
@@ -807,37 +214,6 @@ checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
  "pkg-config",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -984,45 +360,3 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "xkbcommon-rs"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e7409adab994ba3fb241b9d7f71335ccc2216525b990be568064e1ae2e3705"
-dependencies = [
- "bitflags",
- "indexmap",
- "lalrpop",
- "lalrpop-util",
- "log",
- "logos",
- "nix 0.28.0",
- "phf",
- "phf_shared",
- "strum",
- "strum_macros",
- "thiserror",
- "unicase",
- "xkbcommon-rs-codegen",
- "xkeysym",
-]
-
-[[package]]
-name = "xkbcommon-rs-codegen"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d346404312bc1badb468f2a9b2eeb8e61514eb5892ca8246488f53bac4e3fc8"
-dependencies = [
- "convert_case",
- "phf",
- "phf_codegen",
- "regex",
- "unicase",
-]
-
-[[package]]
-name = "xkeysym"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2024"
 build = "build.rs"
 
 [dependencies]
-memmap2 = "0.9.5"
 nix = { version = "0.30.1", features = [ "fs", "event" ] }
 wayland-client = "0.31.10"
 wayland-protocols = { version = "0.32.8", features = [ "client", "staging" ] }
-xkbcommon-rs = "0.1.2"
 
 [build-dependencies]
 cmake = "0.1"

--- a/TESTS.md
+++ b/TESTS.md
@@ -11,3 +11,5 @@ The `test` directory contains some helpful tests for the renderer.
 - `test_img.qml`
     - Shows a full screen image with blur.
     - Good for testing graphical effects.
+- `test_keys.qml`
+    - For testing keyboard input

--- a/build.rs
+++ b/build.rs
@@ -26,5 +26,7 @@ fn main() {
     println!("cargo:rustc-link-lib=stdc++");
     println!("cargo:rustc-link-lib=GLESv2");
 
+    println!("cargo:rustc-link-lib=xkbcommon");
+
     println!("cargo:rerun-if-changed=cpp/");
 }

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Qt6 COMPONENTS Core Quick REQUIRED)
 
 add_library(${PROJECT_NAME} STATIC
   src/render.cpp
+  src/event_handler.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PROJECT_NAME} STATIC
   src/render.cpp
   src/event_handler.cpp
   src/keyboard.cpp
+  src/keymap.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,15 +12,23 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 find_package(Qt6 COMPONENTS Core Quick REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(XKBCOMMON REQUIRED xkbcommon)
 
 add_library(${PROJECT_NAME} STATIC
   src/render.cpp
   src/event_handler.cpp
+  src/keyboard.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
   Qt6::Core
   Qt6::Quick
+  ${XKBCOMMON_LIBRARIES}
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${XKBCOMMON_INCLUDE_DIRS}
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -15,7 +15,10 @@ extern "C" {
 enum class EventType : uint64_t {
     Wayland = 1,
     Renderer = 2,
-    Keyboard = 3,
+    KeyboardKeymap = 3,
+    KeyboardKey = 4,
+    KeyboardModifiers = 5,
+    KeyboardRepeatInfo = 6,
 };
 
 typedef uint64_t EventParam;

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -15,6 +15,7 @@ extern "C" {
 enum class EventType : uint64_t {
     Wayland = 1,
     Renderer = 2,
+    Keyboard = 3,
 };
 
 typedef uint64_t EventParam;

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -25,13 +25,19 @@ int readEvent(int fd, Event *event) {
     return 0;
 }
 
-
-EventHandler::EventHandler(QmlRenderer *renderer) : m_renderer(renderer) {}
+EventHandler::EventHandler(QmlRenderer *renderer) : m_renderer(renderer) {
+    this->m_keyboardHandler = new KeyboardHandler(renderer);
+}
 
 EventHandler::~EventHandler() = default;
 
 int EventHandler::processEvent(EventType event_type, EventParam param_1,
                                EventParam param_2) {
+    switch (event_type) {
+        case EventType::KeyboardKeymap: {
+            this->m_keyboardHandler->handleKeymapEvent(param_1, param_2);
+        }
+    }
     std::cout << "Event Type: " << static_cast<uint64_t>(event_type)
               << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";
     std::cout.flush();

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -37,6 +37,14 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
         case EventType::KeyboardKeymap: {
             this->m_keyboardHandler->handleKeymapEvent(param_1, param_2);
         }
+        case EventType::KeyboardModifiers: {
+            // Modifiers bit packed:
+            // param_1: 31 [mods_depressed] [mods_latched] 0
+            // param_2: 31 [  mods_locked ] [    group   ] 0
+            this->m_keyboardHandler->handleModifiersEvent(
+                param_1 >> 32, param_1 & 0xFFFF, param_2 >> 32,
+                param_2 & 0xFFFF);
+        }
     }
     std::cout << "Event Type: " << static_cast<uint64_t>(event_type)
               << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#include "event_handler.hpp"
+#include "render.hpp"
+#include <errno.h>
+#include <iostream>
+#include <unistd.h>
+
+int readEvent(int fd, Event *event) {
+    ssize_t res = read(fd, event, sizeof(Event));
+    if (res == -1) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return -1;
+        } else {
+            std::cerr << "Failed to read event: " << strerror(errno) << "\n";
+            return -1;
+        }
+    } else if (res != sizeof(Event)) {
+        std::cerr << "Partial read: expected " << sizeof(Event)
+                  << " bytes, got " << res << "\n";
+        return -1;
+    }
+
+    return 0;
+}
+
+
+EventHandler::EventHandler(QmlRenderer *renderer) : m_renderer(renderer) {}
+
+EventHandler::~EventHandler() = default;
+
+int EventHandler::processEvent(EventType event_type, EventParam param_1,
+                               EventParam param_2) {
+    std::cout << "Event Type: " << static_cast<uint64_t>(event_type)
+              << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";
+    std::cout.flush();
+    return 0;
+}
+
+void EventHandler::handleReceivedEvent() {
+    Event ev = {};
+    int result = readEvent(m_renderer->appState->rendererReadFd, &ev);
+
+    if (result == 0) {
+        processEvent(ev.event_type, ev.param_1, ev.param_2);
+    }
+}

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025, Nathan Gill
 
 #include "event_handler.hpp"
+#include "keyboard.hpp"
 #include "render.hpp"
 #include <errno.h>
 #include <iostream>
@@ -26,7 +27,7 @@ int readEvent(int fd, Event *event) {
 }
 
 EventHandler::EventHandler(QmlRenderer *renderer) : m_renderer(renderer) {
-    this->m_keyboardHandler = new KeyboardHandler(renderer);
+    m_keyboardHandler = new KeyboardHandler(renderer);
 }
 
 EventHandler::~EventHandler() = default;
@@ -35,15 +36,19 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
                                EventParam param_2) {
     switch (event_type) {
         case EventType::KeyboardKeymap: {
-            this->m_keyboardHandler->handleKeymapEvent(param_1, param_2);
+            m_keyboardHandler->handleKeymapEvent(param_1, param_2);
         }
         case EventType::KeyboardModifiers: {
             // Modifiers bit packed:
             // param_1: 31 [mods_depressed] [mods_latched] 0
             // param_2: 31 [  mods_locked ] [    group   ] 0
-            this->m_keyboardHandler->handleModifiersEvent(
+            m_keyboardHandler->handleModifiersEvent(
                 param_1 >> 32, param_1 & 0xFFFF, param_2 >> 32,
                 param_2 & 0xFFFF);
+        }
+        case EventType::KeyboardKey: {
+            m_keyboardHandler->handleKeyEvent(param_1,
+                                              static_cast<KeyState>(param_2));
         }
     }
     std::cout << "Event Type: " << static_cast<uint64_t>(event_type)

--- a/cpp/src/event_handler.hpp
+++ b/cpp/src/event_handler.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#pragma once
+
+#ifndef EVENT_HANDLER_HPP
+#define EVENT_HANDLER_HPP
+
+#include "event.hpp"
+#include <memory>
+
+struct QmlRenderer;
+
+class EventHandler {
+  private:
+    QmlRenderer *m_renderer;
+
+  public:
+    explicit EventHandler(QmlRenderer *renderer);
+    ~EventHandler();
+
+    int processEvent(EventType event_type, EventParam param_1,
+                     EventParam param_2);
+    void handleReceivedEvent();
+};
+
+#endif

--- a/cpp/src/event_handler.hpp
+++ b/cpp/src/event_handler.hpp
@@ -7,15 +7,17 @@
 #define EVENT_HANDLER_HPP
 
 #include "event.hpp"
+#include "keyboard.hpp"
 #include <memory>
 
 struct QmlRenderer;
 
 class EventHandler {
-  private:
+private:
     QmlRenderer *m_renderer;
+    KeyboardHandler *m_keyboardHandler;
 
-  public:
+public:
     explicit EventHandler(QmlRenderer *renderer);
     ~EventHandler();
 

--- a/cpp/src/event_handler.hpp
+++ b/cpp/src/event_handler.hpp
@@ -7,10 +7,10 @@
 #define EVENT_HANDLER_HPP
 
 #include "event.hpp"
-#include "keyboard.hpp"
 #include <memory>
 
 struct QmlRenderer;
+class KeyboardHandler;
 
 class EventHandler {
 private:

--- a/cpp/src/keyboard.cpp
+++ b/cpp/src/keyboard.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025, Nathan Gill
 
 #include "keyboard.hpp"
+#include "render.hpp"
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <iostream>
@@ -13,14 +14,14 @@ KeyboardHandler::KeyboardHandler(QmlRenderer *renderer)
       m_xkbState(nullptr) {}
 
 KeyboardHandler::~KeyboardHandler() {
-    if (this->m_xkbContext) {
-        xkb_context_unref(this->m_xkbContext);
+    if (m_xkbContext) {
+        xkb_context_unref(m_xkbContext);
     }
 }
 
 void KeyboardHandler::setupXkbContext() {
-    this->m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!this->m_xkbContext) {
+    m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!m_xkbContext) {
         std::cerr << "Failed to create XKB context\n";
     }
 
@@ -74,9 +75,68 @@ void KeyboardHandler::handleModifiersEvent(uint32_t mods_depressed,
                                            uint32_t mods_latched,
                                            uint32_t mods_locked,
                                            uint32_t group) {
-    if (this->m_xkbState) {
-        xkb_state_update_mask(this->m_xkbState, mods_depressed, mods_latched,
+    if (m_xkbState) {
+        xkb_state_update_mask(m_xkbState, mods_depressed, mods_latched,
                               mods_locked, 0, 0, group);
         std::cout << "Updated modifiers\n";
+    }
+}
+
+void KeyboardHandler::handleKeyEvent(uint32_t key_code, KeyState state) {
+    if (!m_xkbState) {
+        std::cout << "No XKB state available" << std::endl;
+        return;
+    }
+
+    uint32_t xkb_keycode = key_code + 8;
+
+    if (state == KeyState::Pressed) {
+        xkb_state_update_key(m_xkbState, xkb_keycode, XKB_KEY_DOWN);
+    } else if (state == KeyState::Released) {
+        xkb_state_update_key(m_xkbState, xkb_keycode, XKB_KEY_UP);
+    }
+
+    xkb_keysym_t keysym = xkb_state_key_get_one_sym(m_xkbState, xkb_keycode);
+
+    Qt::Key key = xkbKeysymToQtKey(keysym);
+
+    char buffer[64];
+    int size =
+        xkb_state_key_get_utf8(m_xkbState, xkb_keycode, buffer, sizeof(buffer));
+    QString text;
+    if (size > 0) {
+        text = QString::fromUtf8(buffer, size);
+    }
+
+    Qt::KeyboardModifiers modifiers = xkbStateToQtModifiers();
+
+    if (state == KeyState::Pressed) {
+        sendKeyEvent(QEvent::KeyPress, key, modifiers, text);
+    } else if (state == KeyState::Released) {
+        sendKeyEvent(QEvent::KeyRelease, key, modifiers, text);
+    }
+}
+
+void KeyboardHandler::sendKeyEvent(QEvent::Type eventType, Qt::Key key,
+                                   Qt::KeyboardModifiers modifiers,
+                                   const QString &text) {
+    QKeyEvent *event = new QKeyEvent(eventType, key, modifiers, text);
+    QObject *target = nullptr;
+
+    if (QGuiApplication::focusObject()) {
+        target = QGuiApplication::focusObject();
+    } else if (m_renderer->window && m_renderer->window->activeFocusItem()) {
+        target = m_renderer->window->activeFocusItem();
+    } else if (m_renderer->rootItem) {
+        target = m_renderer->rootItem;
+    } else if (m_renderer->window) {
+        target = m_renderer->window;
+    }
+
+    if (target) {
+        std::cout << "Sent key event\n";
+        QCoreApplication::postEvent(target, event);
+    } else {
+        delete event;
     }
 }

--- a/cpp/src/keyboard.cpp
+++ b/cpp/src/keyboard.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#include "keyboard.hpp"
+#include <QCoreApplication>
+#include <QGuiApplication>
+#include <iostream>
+#include <sys/mman.h>
+#include <unistd.h>
+
+KeyboardHandler::KeyboardHandler(QmlRenderer *renderer)
+    : m_renderer(renderer), m_xkbContext(nullptr), m_xkbKeymap(nullptr),
+      m_xkbState(nullptr) {}
+
+KeyboardHandler::~KeyboardHandler() {
+    if (this->m_xkbContext) {
+        xkb_context_unref(this->m_xkbContext);
+    }
+}
+
+void KeyboardHandler::setupXkbContext() {
+    this->m_xkbContext = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!this->m_xkbContext) {
+        std::cerr << "Failed to create XKB context\n";
+    }
+
+    std::cout << "Created new XKB context\n";
+}
+
+void KeyboardHandler::handleKeymapEvent(int fd, uint32_t size) {
+    if (!m_xkbContext) {
+        setupXkbContext();
+    }
+
+    char *keymap_str =
+        static_cast<char *>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0));
+    if (keymap_str == MAP_FAILED) {
+        std::cerr << "Failed to mmap keymap\n";
+        close(fd);
+        return;
+    }
+
+    struct xkb_keymap *keymap = xkb_keymap_new_from_string(
+        m_xkbContext, keymap_str, XKB_KEYMAP_FORMAT_TEXT_V1,
+        XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    munmap(keymap_str, size);
+    close(fd);
+
+    if (!keymap) {
+        std::cerr << "Failed to create XKB keymap\n";
+        return;
+    }
+
+    if (m_xkbState) {
+        xkb_state_unref(m_xkbState);
+    }
+    if (m_xkbKeymap) {
+        xkb_keymap_unref(m_xkbKeymap);
+    }
+
+    m_xkbKeymap = keymap;
+    m_xkbState = xkb_state_new(keymap);
+
+    if (!m_xkbState) {
+        std::cerr << "Failed to create XKB state\n";
+        return;
+    }
+
+    std::cout << "Loaded new XKB keymap\n";
+}

--- a/cpp/src/keyboard.cpp
+++ b/cpp/src/keyboard.cpp
@@ -69,3 +69,14 @@ void KeyboardHandler::handleKeymapEvent(int fd, uint32_t size) {
 
     std::cout << "Loaded new XKB keymap\n";
 }
+
+void KeyboardHandler::handleModifiersEvent(uint32_t mods_depressed,
+                                           uint32_t mods_latched,
+                                           uint32_t mods_locked,
+                                           uint32_t group) {
+    if (this->m_xkbState) {
+        xkb_state_update_mask(this->m_xkbState, mods_depressed, mods_latched,
+                              mods_locked, 0, 0, group);
+        std::cout << "Updated modifiers\n";
+    }
+}

--- a/cpp/src/keyboard.hpp
+++ b/cpp/src/keyboard.hpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#pragma once
+
+#ifndef KEYBOARD_HPP
+#define KEYBOARD_HPP
+
+#include <QKeyEvent>
+#include <QString>
+#include <cstdint>
+#include <xkbcommon/xkbcommon.h>
+
+struct QmlRenderer;
+
+class KeyboardHandler {
+private:
+    QmlRenderer *m_renderer;
+    struct xkb_context *m_xkbContext;
+    struct xkb_keymap *m_xkbKeymap;
+    struct xkb_state *m_xkbState;
+
+public:
+    explicit KeyboardHandler(QmlRenderer *renderer);
+    ~KeyboardHandler();
+
+    void setupXkbContext();
+    void handleKeymapEvent(int fd, uint32_t size);
+};
+
+#endif

--- a/cpp/src/keyboard.hpp
+++ b/cpp/src/keyboard.hpp
@@ -11,6 +11,12 @@
 #include <cstdint>
 #include <xkbcommon/xkbcommon.h>
 
+enum class KeyState : uint32_t {
+    Released = 0,
+    Pressed = 1,
+    Repeated = 2,
+};
+
 struct QmlRenderer;
 
 class KeyboardHandler {
@@ -28,6 +34,13 @@ public:
     void handleKeymapEvent(int fd, uint32_t size);
     void handleModifiersEvent(uint32_t mods_depressed, uint32_t mods_latched,
                               uint32_t mods_locked, uint32_t group);
+    void handleKeyEvent(uint32_t key_code, KeyState state);
+
+    Qt::Key xkbKeysymToQtKey(xkb_keysym_t keysym);
+    Qt::KeyboardModifiers xkbStateToQtModifiers();
+
+    void sendKeyEvent(QEvent::Type eventType, Qt::Key key,
+                      Qt::KeyboardModifiers modifiers, const QString &text);
 };
 
 #endif

--- a/cpp/src/keyboard.hpp
+++ b/cpp/src/keyboard.hpp
@@ -26,6 +26,8 @@ public:
 
     void setupXkbContext();
     void handleKeymapEvent(int fd, uint32_t size);
+    void handleModifiersEvent(uint32_t mods_depressed, uint32_t mods_latched,
+                              uint32_t mods_locked, uint32_t group);
 };
 
 #endif

--- a/cpp/src/keymap.cpp
+++ b/cpp/src/keymap.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#include "keyboard.hpp"
+
+Qt::Key KeyboardHandler::xkbKeysymToQtKey(xkb_keysym_t keysym) {
+    if (keysym >= 0x20 && (keysym < 0xD800 || keysym > 0xDFFF) &&
+        keysym <= 0x10FFFF) {
+        if (keysym >= 'a' && keysym <= 'z') {
+            // All Qt keys are uppercase
+            return static_cast<Qt::Key>(keysym - 'a' + 'A');
+        } else {
+            return static_cast<Qt::Key>(keysym);
+        }
+    }
+
+    switch (keysym) {
+        default:
+            return Qt::Key_unknown;
+    }
+}
+
+Qt::KeyboardModifiers KeyboardHandler::xkbStateToQtModifiers() {
+    Qt::KeyboardModifiers modifiers = Qt::NoModifier;
+
+    if (!m_xkbState) {
+        return modifiers;
+    }
+
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_SHIFT,
+                                     XKB_STATE_MODS_EFFECTIVE)) {
+        modifiers |= Qt::ShiftModifier;
+    }
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_CTRL,
+                                     XKB_STATE_MODS_EFFECTIVE)) {
+        modifiers |= Qt::ControlModifier;
+    }
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_ALT,
+                                     XKB_STATE_MODS_EFFECTIVE)) {
+        modifiers |= Qt::AltModifier;
+    }
+    if (xkb_state_mod_name_is_active(m_xkbState, XKB_MOD_NAME_LOGO,
+                                     XKB_STATE_MODS_EFFECTIVE)) {
+        modifiers |= Qt::MetaModifier;
+    }
+
+    return modifiers;
+}

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -129,13 +129,6 @@ int read_event(int fd, Event *event) {
 
 int event_handler(QmlRenderer *renderer, EventType event_type,
                   EventParam param_1, EventParam param_2) {
-
-    switch (event_type) {
-    case EventType::Keyboard: {
-    }
-    default:
-        return 1;
-    }
     std::cout << "Event Type: " << (uint64_t)event_type
               << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";
     std::cout.flush();

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -160,6 +160,7 @@ void setup_renderer_signals(QmlRenderer *renderer) {
                 rootItem->setWidth(renderer->fbSize.width());
                 rootItem->setHeight(renderer->fbSize.height());
 
+                renderer->rootItem = rootItem;
                 renderer->running = true;
             } else if (renderer->component->status() == QQmlComponent::Error) {
                 std::cerr << "QML Component has errors:" << std::endl;

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -127,15 +127,27 @@ int read_event(int fd, Event *event) {
     return 0;
 }
 
+int event_handler(QmlRenderer *renderer, EventType event_type,
+                  EventParam param_1, EventParam param_2) {
+
+    switch (event_type) {
+    case EventType::Keyboard: {
+    }
+    default:
+        return 1;
+    }
+    std::cout << "Event Type: " << (uint64_t)event_type
+              << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";
+    std::cout.flush();
+    return 0;
+}
+
 void handle_received_event(QmlRenderer *renderer) {
     Event ev = {};
     int result = read_event(renderer->appState->rendererReadFd, &ev);
 
     if (result == 0) {
-        std::cout << "Event Type: " << (uint64_t)ev.event_type
-                  << "; Param 1: " << ev.param_1 << "; Param 2: " << ev.param_2
-                  << "\n";
-        std::cout.flush();
+        event_handler(renderer, ev.event_type, ev.param_1, ev.param_2);
     }
 }
 

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -6,12 +6,82 @@
 #ifndef RENDER_HPP
 #define RENDER_HPP
 
+#include <QDebug>
+#include <QGuiApplication>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickRenderControl>
+#include <QQuickRenderTarget>
+#include <QQuickWindow>
+#include <QSocketNotifier>
+#include <QSurfaceFormat>
+#include <QTimer>
+#include <QVariant>
+
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <unistd.h>
+
+#include "event.hpp"
+#include "event_handler.hpp"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct QmlRenderer;
-struct ApplicationState;
+typedef void *(*RsGetBufferCallback)(void *user_data);
+
+struct ApplicationState {
+    const char *qmlPath;
+    int state;
+    void *renderer;
+    int rendererWriteFd;
+    int rendererReadFd;
+};
+
+struct QmlRenderer {
+    QGuiApplication *app;
+    QSize fbSize;
+    QOpenGLContext *context;
+    QSurfaceFormat *surfaceFormat;
+    QOffscreenSurface *surface;
+    QQuickRenderControl *renderControl;
+    QQuickWindow *window;
+    QOpenGLFramebufferObjectFormat *fbFormat;
+    QOpenGLFramebufferObject *fb;
+    QQmlEngine *engine;
+    QQmlComponent *component;
+    QSocketNotifier *eventSocketNotifier;
+
+    const char *qmlPath;
+    bool running = false;
+
+    RsGetBufferCallback getBufferCallback = nullptr;
+    void *userData = nullptr;
+
+    std::thread renderThread;
+    std::atomic<bool> threadRunning{false};
+    std::atomic<bool> shouldStop{false};
+    std::mutex initMutex;
+    std::condition_variable initCondition;
+    std::atomic<bool> initialized{false};
+
+    EventHandler *eventHandler;
+    ApplicationState *appState;
+};
 
 typedef void *(*RsGetBufferCallback)(void *user_data);
 
@@ -20,6 +90,7 @@ QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath,
 int start_renderer(QmlRenderer *renderer);
 void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer,
                    void *userData);
+int render(const QOpenGLFramebufferObject &fbo, void *buffer);
 void cleanup_renderer(QmlRenderer *renderer);
 
 #ifdef __cplusplus

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -36,7 +36,8 @@
 #include <unistd.h>
 
 #include "event.hpp"
-#include "event_handler.hpp"
+
+class EventHandler;
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +66,7 @@ struct QmlRenderer {
     QQmlEngine *engine;
     QQmlComponent *component;
     QSocketNotifier *eventSocketNotifier;
+    QQuickItem *rootItem;
 
     const char *qmlPath;
     bool running = false;

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -11,10 +11,12 @@ extern "C" {
 #endif
 
 struct QmlRenderer;
+struct ApplicationState;
 
 typedef void *(*RsGetBufferCallback)(void *user_data);
 
-QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath);
+QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath,
+                                 ApplicationState *appState);
 int start_renderer(QmlRenderer *renderer);
 void set_callbacks(QmlRenderer *renderer, RsGetBufferCallback getBuffer,
                    void *userData);

--- a/src/wayland/event/event.rs
+++ b/src/wayland/event/event.rs
@@ -6,6 +6,8 @@
         `Event` and `EventType` objects for event handling
 */
 
+use std::os::fd::OwnedFd;
+
 use crate::wayland::event::{event_param::EventParam, event_type::EventType};
 
 /// Event structure containing event serial, type, and parameters
@@ -44,5 +46,16 @@ impl Event {
     /// This function is not responsible for proper pointer management.
     pub unsafe fn from_mut_ptr(ptr: *mut Event) -> Self {
         unsafe { std::ptr::read(ptr) }
+    }
+
+    /// Write this object into a file specified by `fd`
+    pub fn write_to(&self, fd: &OwnedFd) -> Result<(), Box<dyn std::error::Error>> {
+        let event_ptr = self as *const Event as *const u8;
+        let event_buf =
+            unsafe { std::slice::from_raw_parts(event_ptr, std::mem::size_of::<Event>()) };
+
+        nix::unistd::write(fd, event_buf)?;
+
+        Ok(())
     }
 }

--- a/src/wayland/event/event_loop.rs
+++ b/src/wayland/event/event_loop.rs
@@ -87,6 +87,7 @@ impl WaylandState {
                 EventType::Renderer => {
                     self.handle_renderer_event()?;
                 }
+                _ => {}
             }
         }
 

--- a/src/wayland/event/event_param.rs
+++ b/src/wayland/event/event_param.rs
@@ -59,3 +59,9 @@ impl From<*const c_void> for EventParam {
         EventParam(ptr as u64)
     }
 }
+
+impl From<u64> for EventParam {
+    fn from(value: u64) -> Self {
+        EventParam(value)
+    }
+}

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -14,7 +14,10 @@
 pub enum EventType {
     Wayland = 1,
     Renderer = 2,
-    Keyboard = 3,
+    KeyboardKeymap = 3,
+    KeyboardKey = 4,
+    KeyboardModifiers = 5,
+    KeyboardRepeatInfo = 6,
 }
 
 impl TryFrom<u64> for EventType {
@@ -25,7 +28,10 @@ impl TryFrom<u64> for EventType {
         match tag {
             1 => Ok(EventType::Wayland),
             2 => Ok(EventType::Renderer),
-            3 => Ok(EventType::Keyboard),
+            3 => Ok(EventType::KeyboardKeymap),
+            4 => Ok(EventType::KeyboardKey),
+            5 => Ok(EventType::KeyboardModifiers),
+            6 => Ok(EventType::KeyboardRepeatInfo),
             _ => Err("Invalid EventType tag"),
         }
     }

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -14,6 +14,7 @@
 pub enum EventType {
     Wayland = 1,
     Renderer = 2,
+    Keyboard = 3,
 }
 
 impl TryFrom<u64> for EventType {
@@ -24,6 +25,7 @@ impl TryFrom<u64> for EventType {
         match tag {
             1 => Ok(EventType::Wayland),
             2 => Ok(EventType::Renderer),
+            3 => Ok(EventType::Keyboard),
             _ => Err("Invalid EventType tag"),
         }
     }

--- a/src/wayland/input/keyboard.rs
+++ b/src/wayland/input/keyboard.rs
@@ -3,19 +3,15 @@
 
 /*
     keyboard.rs:
-        Obtains a keymap which can be used to get key values from scancodes,
-        and contains basic keypress handling.
+        Acquires a keyboard interface and redirects keyboard events to Qt
 */
 
 use crate::wayland::{
     event::{event::Event, event_param::EventParam, event_type::EventType},
     state::WaylandState,
 };
-use memmap2::MmapOptions;
-use std::{
-    fs::File,
-    os::fd::{FromRawFd, IntoRawFd},
-};
+
+use std::os::fd::IntoRawFd;
 use wayland_client::{
     Connection, Dispatch, QueueHandle, WEnum,
     protocol::{
@@ -23,14 +19,6 @@ use wayland_client::{
         wl_seat::{self, Capability, WlSeat},
     },
 };
-use xkbcommon_rs::{Keymap, State};
-
-pub struct KeyboardMapping {
-    pub file: std::fs::File,
-    pub mmap: memmap2::Mmap,
-    pub keymap: Option<Keymap>,
-    pub state: Option<State>,
-}
 
 impl Dispatch<WlKeyboard, ()> for WaylandState {
     fn event(
@@ -41,91 +29,78 @@ impl Dispatch<WlKeyboard, ()> for WaylandState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
+        // Redirect events into the Qt event loop for further processing
         match event {
             wl_keyboard::Event::Keymap { format, fd, size } => {
                 if format == WEnum::Value(KeymapFormat::XkbV1) {
-                    let file = unsafe { File::from_raw_fd(fd.into_raw_fd()) };
-                    let mmap_result = unsafe { MmapOptions::new().len(size as usize).map(&file) };
-                    match mmap_result {
-                        Ok(mmap) => {
-                            let keymap_str =
-                                std::str::from_utf8(&mmap).expect("Keymap mmap is not valid UTF-8");
-                            let keymap_result = xkbcommon_rs::Keymap::new_from_string(
-                                xkbcommon_rs::Context::new(0).unwrap(),
-                                keymap_str,
-                                xkbcommon_rs::KeymapFormat::TextV1,
-                                0,
-                            );
-
-                            match keymap_result {
-                                Ok(keymap) => {
-                                    let state = State::new(keymap.clone());
-                                    let mapping = KeyboardMapping {
-                                        file: file,
-                                        mmap: mmap,
-                                        keymap: Some(keymap),
-                                        state: Some(state),
-                                    };
-                                    wayland_state.keymap = Some(mapping);
-                                    println!("Found xkbV1 format keymap and created state.");
-                                }
-                                Err(_) => {
-                                    println!("Error compiling keymap.");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to mmap keymap file: {}", e);
-                        }
-                    }
+                    let event = Event::new(
+                        EventType::KeyboardKeymap,
+                        EventParam::from(fd.into_raw_fd() as u64),
+                        EventParam::from(size as u64),
+                    );
+                    let _ = event.write_to(
+                        wayland_state
+                            .renderer_write_pipe
+                            .as_ref()
+                            .unwrap()
+                            .write_fd(),
+                    );
                 }
             }
             wl_keyboard::Event::Key {
                 serial: _,
                 time: _,
                 key,
-                state: _,
+                state,
             } => {
-                if let Some(ref keymap) = wayland_state.keymap {
-                    if let (Some(_keymap_file), Some(state)) = (&keymap.keymap, &keymap.state) {
-                        let keycode = key + 8;
-                        let keysym = state.key_get_one_sym(keycode);
-                        let s = xkbcommon_rs::keysym::keysym_get_name(&keysym.unwrap()).unwrap();
-                        println!("Pressed: {}", s);
-
-                        // Write a dummy event into the renderer's event pipe
-                        let event = Event::new(
-                            EventType::Keyboard,
-                            EventParam::from(0),
-                            EventParam::from(0),
-                        );
-                        let event_ptr = &event as *const Event as *const u8;
-                        let event_buf = unsafe {
-                            std::slice::from_raw_parts(event_ptr, std::mem::size_of::<Event>())
-                        };
-
-                        match nix::unistd::write(
-                            wayland_state
-                                .renderer_write_pipe
-                                .as_ref()
-                                .unwrap()
-                                .write_fd(),
-                            event_buf,
-                        ) {
-                            Ok(_) => {
-                                // Event sent successfully
-                            }
-                            Err(nix::errno::Errno::EAGAIN) => {
-                                println!(
-                                    "Warning: Dropping keyboard event, renderer pipe buffer full"
-                                );
-                            }
-                            Err(e) => {
-                                println!("Failed to send keyboard event to renderer: {}", e);
-                            }
-                        }
-                    }
-                }
+                let event = Event::new(
+                    EventType::KeyboardKey,
+                    EventParam::from(key as u64),
+                    EventParam::from(match state {
+                        WEnum::Value(val) => val as u64,
+                        WEnum::Unknown(val) => val as u64,
+                    }),
+                );
+                let _ = event.write_to(
+                    wayland_state
+                        .renderer_write_pipe
+                        .as_ref()
+                        .unwrap()
+                        .write_fd(),
+                );
+            }
+            wl_keyboard::Event::Modifiers {
+                serial: _,
+                mods_depressed,
+                mods_latched,
+                mods_locked,
+                group,
+            } => {
+                let param_1 =
+                    EventParam::from(((mods_depressed as u64) << 32) | (mods_latched as u64));
+                let param_2 = EventParam::from(((mods_locked as u64) << 32) | (group as u64));
+                let event = Event::new(EventType::KeyboardModifiers, param_1, param_2);
+                let _ = event.write_to(
+                    wayland_state
+                        .renderer_write_pipe
+                        .as_ref()
+                        .unwrap()
+                        .write_fd(),
+                );
+            }
+            wl_keyboard::Event::RepeatInfo { rate, delay } => {
+                let event = Event::new(
+                    EventType::KeyboardRepeatInfo,
+                    EventParam::from(rate as u64),
+                    EventParam::from(delay as u64),
+                );
+                let _ = event.write_to(
+                    wayland_state
+                        .renderer_write_pipe
+                        .as_ref()
+                        .unwrap()
+                        .write_fd(),
+                );
             }
             _ => {}
         }

--- a/src/wayland/state.rs
+++ b/src/wayland/state.rs
@@ -8,10 +8,10 @@
 */
 
 use crate::shared::interface::{get_state, set_renderer_read_fd, set_renderer_write_fd};
+use crate::shared::state::ApplicationState;
 use crate::shared::{interface::set_state, state::State};
 use crate::wayland::buffer::manager::BufferManager;
 use crate::wayland::communication::pipe::Pipe;
-use crate::{shared::state::ApplicationState, wayland::input::keyboard::KeyboardMapping};
 use std::os::fd::AsRawFd;
 use wayland_client::EventQueue;
 use wayland_client::{
@@ -53,8 +53,6 @@ pub struct WaylandState {
 
     pub keyboard: Option<WlKeyboard>,
 
-    pub keymap: Option<KeyboardMapping>,
-
     pub viewport: Option<WpViewport>,
 
     pub width: i32,
@@ -87,7 +85,6 @@ impl WaylandState {
             session_lock: None,
             session_lock_surface: None,
             keyboard: None,
-            keymap: None,
             viewport: None,
             width: -1,
             height: -1,

--- a/test/test_keys.qml
+++ b/test/test_keys.qml
@@ -1,0 +1,25 @@
+import QtQuick 6.0
+
+Rectangle {
+    id: root
+    width: 400
+    height: 300
+    focus: true
+    color: colors[colorIndex]
+
+    property int colorIndex: 0
+    property var colors: ["black", "darkblue", "darkgreen", "darkred", "darkmagenta", "darkcyan"]
+    property string lastKey: ""
+
+    Keys.onReleased: (event) => {
+        colorIndex = (colorIndex + 1) % colors.length
+        lastKey = event.text !== "" ? event.text : event.key
+    }
+
+    Text {
+        anchors.centerIn: parent
+        text: lastKey === "" ? "Press any key" : "Released: " + lastKey
+        font.pixelSize: 24
+        color: "white"
+    }
+}


### PR DESCRIPTION
Send all Wayland keyboard events to Qt so they can be dispatched within the Qt application.
The Qt code translates from Xkb keycodes into Qt compatible ones, using text where needed. Non-printable keys are currently missing.