### PR TITLE
feat: use the `tracing` crate for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cmake",
+ "log",
  "nix",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,37 @@
 version = 4
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
@@ -30,6 +57,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +78,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "downcast-rs"
@@ -52,6 +99,40 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -104,6 +185,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -171,6 +261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +311,7 @@ dependencies = [
 name = "tlockr"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "cmake",
  "nix",
  "tracing",
@@ -291,6 +388,64 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
@@ -370,6 +525,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +71,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -83,6 +95,34 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -131,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,13 +192,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tlockr"
 version = "0.1.0"
 dependencies = [
  "cmake",
  "nix",
+ "tracing",
+ "tracing-subscriber",
  "wayland-client",
  "wayland-protocols",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -157,6 +285,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wayland-backend"
@@ -214,6 +348,28 @@ checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +317,7 @@ dependencies = [
 name = "tlockr"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "cmake",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 build = "build.rs"
 
 [dependencies]
+chrono = "0.4.41"
 nix = { version = "0.30.1", features = [ "fs", "event" ] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ build = "build.rs"
 
 [dependencies]
 nix = { version = "0.30.1", features = [ "fs", "event" ] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 wayland-client = "0.31.10"
 wayland-protocols = { version = "0.32.8", features = [ "client", "staging" ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 build = "build.rs"
 
 [dependencies]
+anyhow = "1.0.98"
 chrono = "0.4.41"
 log = "0.4.27"
 nix = { version = "0.30.1", features = [ "fs", "event" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 
 [dependencies]
 chrono = "0.4.41"
+log = "0.4.27"
 nix = { version = "0.30.1", features = [ "fs", "event" ] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(${PROJECT_NAME} STATIC
   src/key_map.cpp
   src/pointer.cpp
   src/button_map.cpp
+  src/logging.cpp
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -3,11 +3,14 @@
 
 #include "event_handler.hpp"
 #include "keyboard.hpp"
+#include "logging.hpp"
 #include "pointer.hpp"
 #include "render.hpp"
 #include <errno.h>
 #include <iostream>
 #include <unistd.h>
+
+static const char *FILENAME = "tlockr_qt/event_handler.cpp";
 
 int readEvent(int fd, Event *event) {
     ssize_t res = read(fd, event, sizeof(Event));
@@ -15,12 +18,15 @@ int readEvent(int fd, Event *event) {
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             return -1;
         } else {
-            std::cerr << "Failed to read event: " << strerror(errno) << "\n";
+            error_log(
+                FILENAME,
+                format_log("Failed to read event: ", strerror(errno)).c_str());
             return -1;
         }
     } else if (res != sizeof(Event)) {
-        std::cerr << "Partial read: expected " << sizeof(Event)
-                  << " bytes, got " << res << "\n";
+        error_log(FILENAME, format_log("Partial read: expected ", sizeof(Event),
+                                       " bytes, got ", res)
+                                .c_str());
         return -1;
     }
 
@@ -67,9 +73,11 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
             break;
         }
     }
-    std::cout << "Event Type: " << static_cast<uint64_t>(event_type)
-              << "; Param 1: " << param_1 << "; Param 2: " << param_2 << "\n";
-    std::cout.flush();
+
+    debug_log(FILENAME,
+              format_log("Event Type: ", static_cast<uint64_t>(event_type),
+                         "; Param 1: ", param_1, "; Param 2: ", param_2)
+                  .c_str());
     return 0;
 }
 

--- a/cpp/src/logging.cpp
+++ b/cpp/src/logging.cpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#include "logging.hpp"
+
+void qtMessageHandler(QtMsgType type, const QMessageLogContext &,
+                      const QString &msg) {
+    QByteArray localMsg = msg.toLocal8Bit();
+
+    switch (type) {
+        case QtDebugMsg:
+            debug_log("tlockr_qt", localMsg.constData());
+            break;
+        case QtInfoMsg:
+            info_log("tlockr_qt", localMsg.constData());
+            break;
+        case QtWarningMsg:
+            warn_log("tlockr_qt", localMsg.constData());
+            break;
+        case QtCriticalMsg:
+        case QtFatalMsg:
+            error_log("tlockr_qt", localMsg.constData());
+            break;
+    }
+}

--- a/cpp/src/logging.hpp
+++ b/cpp/src/logging.hpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+#pragma once
+
+#ifndef LOGGING_HPP
+#define LOGGING_HPP
+
+#include <sstream>
+
+template <typename... Args> std::string format_log(Args &&...args) {
+    std::ostringstream ss;
+    (ss << ... << args);
+    return ss.str();
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void trace_log(const char *file, const char *msg);
+void debug_log(const char *file, const char *msg);
+void info_log(const char *file, const char *msg);
+void warn_log(const char *file, const char *msg);
+void error_log(const char *file, const char *msg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/cpp/src/logging.hpp
+++ b/cpp/src/logging.hpp
@@ -6,6 +6,10 @@
 #ifndef LOGGING_HPP
 #define LOGGING_HPP
 
+#include <QDebug>
+#include <QMessageLogContext>
+#include <QString>
+#include <QtGlobal>
 #include <sstream>
 
 template <typename... Args> std::string format_log(Args &&...args) {
@@ -13,6 +17,9 @@ template <typename... Args> std::string format_log(Args &&...args) {
     (ss << ... << args);
     return ss.str();
 }
+
+void qtMessageHandler(QtMsgType type, const QMessageLogContext &,
+                      const QString &msg);
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpp/src/pointer.cpp
+++ b/cpp/src/pointer.cpp
@@ -3,12 +3,15 @@
 
 #include "pointer.hpp"
 #include "keyboard.hpp"
+#include "logging.hpp"
 #include "render.hpp"
 #include <QCoreApplication>
 #include <QGuiApplication>
 #include <QQuickItem>
 #include <QWindow>
 #include <iostream>
+
+static const char *FILENAME = "tlockr_qt/pointer.cpp";
 
 PointerHandler::PointerHandler(QmlRenderer *renderer,
                                KeyboardHandler *keyboardHandler)
@@ -42,7 +45,7 @@ void PointerHandler::sendMouseEvent(QEvent::Type eventType, QPointF globalPos,
                                     Qt::MouseButton button,
                                     Qt::MouseButtons buttons) {
     if (!m_renderer->window) {
-        std::cerr << "No renderer window available\n";
+        error_log(FILENAME, "No renderer window available");
         return;
     }
 

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -88,6 +88,10 @@ void send_frame_rendered_event(QmlRenderer *renderer, void *buf) {
 void setup_renderer(QmlRenderer *renderer) {
     int argc = 0;
     char **argv = nullptr;
+
+    // Install custom message handler
+    qInstallMessageHandler(qtMessageHandler);
+
     renderer->app = new QGuiApplication(argc, argv);
 
     renderer->context = new QOpenGLContext();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,9 @@
 pub mod shared;
 pub mod wayland;
 
-use std::{env, ffi::CString};
-
-use tracing::{debug, info};
-
 use crate::{shared::state::ApplicationState, wayland::state::WaylandState};
+use std::{env, ffi::CString};
+use tracing::{Level, debug, info};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
@@ -26,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tracing_subscriber::fmt()
         .with_timer(tracing_subscriber::fmt::time::uptime())
-        .with_max_level(tracing::Level::DEBUG)
+        .with_max_level(Level::DEBUG)
         .init();
 
     let now = chrono::Local::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,24 +11,17 @@ pub mod shared;
 pub mod wayland;
 
 use crate::{shared::state::ApplicationState, wayland::state::WaylandState};
+use anyhow::Result;
 use std::{env, ffi::CString};
-use tracing::{Level, debug, info};
+use tracing::{Level, debug, error, info};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
         println!("Usage: tlockr <qml path>");
         return Err("Invalid number of arguments".into());
     }
-
-    tracing_subscriber::fmt()
-        .with_timer(tracing_subscriber::fmt::time::uptime())
-        .with_max_level(Level::DEBUG)
-        .init();
-
-    let now = chrono::Local::now();
-    info!("tlockr started at {}", now.to_rfc3339());
 
     let qml_path_cstring = CString::new(args[1].clone())?;
     let qml_path_raw = qml_path_cstring.into_raw();
@@ -49,4 +42,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     state.destroy_renderer();
 
     Ok(())
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::uptime())
+        .with_max_level(Level::DEBUG)
+        .init();
+
+    let now = chrono::Local::now();
+    info!("tlockr started at {}", now.to_rfc3339());
+
+    match run() {
+        Err(e) => {
+            error!("{:?}", e);
+        }
+        _ => {}
+    }
+
+    let now = chrono::Local::now();
+    info!("tlockr exited at {}", now.to_rfc3339())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ pub mod wayland;
 
 use std::{env, ffi::CString};
 
+use tracing::{debug, info};
+
 use crate::{shared::state::ApplicationState, wayland::state::WaylandState};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,10 +24,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Err("Invalid number of arguments".into());
     }
 
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::uptime())
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
+    let now = chrono::Local::now();
+    info!("tlockr started at {}", now.to_rfc3339());
+
     let qml_path_cstring = CString::new(args[1].clone())?;
     let qml_path_raw = qml_path_cstring.into_raw();
 
-    println!("Initializing Wayland interfaces...");
+    debug!("Initializing Wayland interfaces...");
 
     let mut app_state = ApplicationState::new(qml_path_raw);
     let mut state = WaylandState::new(&mut app_state as *mut ApplicationState);
@@ -34,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     state.roundtrip(&mut event_queue)?;
 
-    println!("Wayland interfaces initialized successfully.");
+    debug!("Wayland interfaces initialized successfully.");
 
     state.run_event_loop(&mut event_queue)?;
 

--- a/src/shared/log.rs
+++ b/src/shared/log.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+/*
+    log.rs:
+        Exposed logging wrappers for external code
+*/
+
+use std::ffi::{CStr, c_char};
+
+unsafe fn cstr_to_str<'a>(ptr: *const c_char) -> &'a str {
+    unsafe { CStr::from_ptr(ptr).to_str().unwrap_or("<invalid utf8>") }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn trace_log(file: *const c_char, msg: *const c_char) {
+    unsafe {
+        let file_str = cstr_to_str(file);
+        let msg_str = cstr_to_str(msg);
+        log::trace!(target: file_str, "{}", msg_str);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn debug_log(file: *const c_char, msg: *const c_char) {
+    unsafe {
+        let file_str = cstr_to_str(file);
+        let msg_str = cstr_to_str(msg);
+        log::debug!(target: file_str, "{}", msg_str);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn info_log(file: *const c_char, msg: *const c_char) {
+    unsafe {
+        let file_str = cstr_to_str(file);
+        let msg_str = cstr_to_str(msg);
+        log::info!(target: file_str, "{}", msg_str);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn warn_log(file: *const c_char, msg: *const c_char) {
+    unsafe {
+        let file_str = cstr_to_str(file);
+        let msg_str = cstr_to_str(msg);
+        log::warn!(target: file_str, "{}", msg_str);
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn error_log(file: *const c_char, msg: *const c_char) {
+    unsafe {
+        let file_str = cstr_to_str(file);
+        let msg_str = cstr_to_str(msg);
+        log::error!(target: file_str, "{}", msg_str);
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,3 +1,4 @@
 pub mod ffi;
 pub mod interface;
+pub mod log;
 pub mod state;

--- a/src/wayland/buffer/manager.rs
+++ b/src/wayland/buffer/manager.rs
@@ -9,6 +9,7 @@
 use crate::wayland::event::event::Event;
 use crate::wayland::state::WaylandState;
 use std::os::raw::c_void;
+use tracing::error;
 use wayland_client::protocol::wl_buffer;
 use wayland_client::protocol::{wl_buffer::WlBuffer, wl_shm::WlShm};
 use wayland_client::{Connection, Dispatch, QueueHandle};
@@ -132,7 +133,7 @@ impl Dispatch<WlBuffer, i32> for WaylandState {
             wl_buffer::Event::Release => {
                 // Release the buffer so it can be used again
                 if let Err(e) = state.buffer_manager.release_buffer(*data as usize) {
-                    println!("{}", e);
+                    error!("{}", e);
                 }
             }
             _ => {}

--- a/src/wayland/buffer/pool.rs
+++ b/src/wayland/buffer/pool.rs
@@ -14,6 +14,7 @@ use std::os::{
     fd::{AsFd, AsRawFd, OwnedFd, RawFd},
     raw::c_void,
 };
+use tracing::debug;
 use wayland_client::protocol::wl_shm;
 use wayland_client::protocol::wl_shm_pool::WlShmPool;
 use wayland_client::{EventQueue, QueueHandle};
@@ -123,7 +124,7 @@ impl BufferManager {
             self.allocate_buffer(&pool, &qh, data_ptr)?;
         }
 
-        println!("Allocated {} buffers: {} bytes", n, size);
+        debug!("Allocated {} buffers: {} bytes", n, size);
 
         Ok(())
     }

--- a/src/wayland/graphics/output.rs
+++ b/src/wayland/graphics/output.rs
@@ -7,6 +7,7 @@
 */
 
 use crate::wayland::state::WaylandState;
+use tracing::debug;
 use wayland_client::{
     Connection, Dispatch, QueueHandle,
     protocol::wl_output::{self, WlOutput},
@@ -29,7 +30,7 @@ impl Dispatch<WlOutput, ()> for WaylandState {
                 refresh: _,
             } => {
                 if flags.into_result().unwrap() == wl_output::Mode::Current {
-                    println!("Output mode: {} x {} pixels", width, height);
+                    debug!("Output mode: {} x {} pixels", width, height);
                     state.width = width;
                     state.height = height;
                 }

--- a/src/wayland/input/seat.rs
+++ b/src/wayland/input/seat.rs
@@ -7,6 +7,7 @@
 */
 
 use crate::wayland::state::WaylandState;
+use tracing::debug;
 use wayland_client::{
     Connection, Dispatch, QueueHandle, WEnum,
     protocol::wl_seat::{self, Capability, WlSeat},
@@ -27,13 +28,13 @@ impl Dispatch<WlSeat, ()> for WaylandState {
                     if bits.contains(Capability::Keyboard) && state.keyboard.is_none() {
                         let keyboard = proxy.get_keyboard(qh, ());
                         state.keyboard = Some(keyboard);
-                        println!("Acquired keyboard input interface.");
+                        debug!("Acquired keyboard input interface.");
                     }
 
                     if bits.contains(Capability::Pointer) && state.pointer.is_none() {
                         let pointer = proxy.get_pointer(qh, ());
                         state.pointer = Some(pointer);
-                        println!("Acquired pointer input interface.");
+                        debug!("Acquired pointer input interface.");
                     }
 
                     if !bits.contains(Capability::Keyboard) && state.keyboard.is_some() {

--- a/src/wayland/lock/lock.rs
+++ b/src/wayland/lock/lock.rs
@@ -10,6 +10,7 @@ use crate::shared::interface::get_renderer;
 use crate::shared::state::State;
 use crate::shared::{ffi::start_renderer, interface::set_state};
 use crate::wayland::state::WaylandState;
+use tracing::{error, info};
 use wayland_client::{Connection, Dispatch, EventQueue, QueueHandle};
 use wayland_protocols::ext::session_lock::v1::client::{
     ext_session_lock_surface_v1::{self, ExtSessionLockSurfaceV1},
@@ -56,7 +57,7 @@ impl Dispatch<ExtSessionLockV1, ()> for WaylandState {
     ) {
         match event {
             ext_session_lock_v1::Event::Locked => {
-                println!("Session is locked");
+                info!("Session is locked");
                 set_state(state.app_state, State::Locked);
                 if let Some(surface) = &state.surface {
                     if let Some(output) = &state.output {
@@ -66,7 +67,7 @@ impl Dispatch<ExtSessionLockV1, ()> for WaylandState {
                 }
             }
             ext_session_lock_v1::Event::Finished => {
-                println!("Session is unlocked");
+                info!("Session is unlocked");
                 set_state(state.app_state, State::Unlocked);
             }
             _ => {}
@@ -95,7 +96,7 @@ impl Dispatch<ExtSessionLockSurfaceV1, ()> for WaylandState {
                     if let Some(renderer) = get_renderer(state.app_state) {
                         start_renderer(renderer);
                     } else {
-                        println!("Renderer was None\n");
+                        error!("Renderer was None\n");
                         return;
                     }
                 }


### PR DESCRIPTION
Use the `tracing` crate for logging in Rust and C++ (Qt, via callbacks).