### PR TITLE
chore: remove `anyhow` crate, since it was unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,7 +311,6 @@ dependencies = [
 name = "tlockr"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "cmake",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 build = "build.rs"
 
 [dependencies]
-anyhow = "1.0.98"
 chrono = "0.4.41"
 log = "0.4.27"
 nix = { version = "0.30.1", features = [ "fs", "event" ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ pub mod shared;
 pub mod wayland;
 
 use crate::{shared::state::ApplicationState, wayland::state::WaylandState};
-use anyhow::Result;
 use nix::libc;
 use std::{env, ffi::CString, fs::OpenOptions, os::fd::AsRawFd};
 use tracing::{Level, debug, error, info};


### PR DESCRIPTION
Remove the `anyhow` crate, it was unused.