### PR TITLE
fix: bad rule in `.clang-format` that would break formatting in some editors

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 BasedOnStyle: LLVM
-AlwaysAddBraces: true
 AccessModifierOffset: -4
 IndentCaseLabels: true
 IndentWidth: 4


### PR DESCRIPTION
Remove a bad rule in `.clang-format` that would break formatting in some editors.