### PR TITLE
chore: switch to the `uzers` crate instead of the unmaintained `users` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
  "memchr",
  "pam-macros",
  "pam-sys",
- "users 0.10.0",
+ "users",
 ]
 
 [[package]]
@@ -489,7 +489,7 @@ dependencies = [
  "pam",
  "tracing",
  "tracing-subscriber",
- "users 0.11.0",
+ "uzers",
  "wayland-client",
  "wayland-protocols",
 ]
@@ -568,10 +568,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
+name = "uzers"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+checksum = "4df81ff504e7d82ad53e95ed1ad5b72103c11253f39238bcc0235b90768a97dd"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ nix = { version = "0.30.1", features = [ "fs", "event" ] }
 pam = "0.8.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-users = "0.11.0"
+uzers = "0.12.1"
 wayland-client = "0.31.10"
 wayland-protocols = { version = "0.32.8", features = [ "client", "staging" ] }
 

--- a/src/auth/state.rs
+++ b/src/auth/state.rs
@@ -12,7 +12,7 @@ use std::{
     sync::atomic::AtomicBool,
 };
 use tracing::{error, info};
-use users::get_current_username;
+use uzers::get_current_username;
 
 /// Holds the state of the authenticator thread
 pub struct AuthenticatorState {


### PR DESCRIPTION
Use `uzers` instead of `users`. `uzers` is actually maintained, resolving 2 security vulnerabilities.