### PR TITLE
feat: send authentication state events to Qt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The root of the content should not be a `Window`, since the content does not use
 tlockr provides interfaces for connecting QML themes with the rest of the application:
 
 - `tlockr.sendAuthSubmit`: submits authentication information, the only argument is the password as a string.
+- `tlockr.{debug,info,warn,error}`: logging functions that send log messages (as strings) to the `tlockr` logger.
+- `tlockr.onAuthStateChange`: signal emitted when the authentication state changes, the state is passed.
 - Future interfaces planned...
 
 When tlockr loads QML content, any errors are displayed in the log.

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -25,9 +25,7 @@ enum class EventType : uint64_t {
     PointerButton = 8,
 
     AuthSubmit = 9,
-    AuthPending = 10,
-    AuthFail = 11,
-    AuthSuccess = 12,
+    AuthStateUpdate = 10,
 };
 
 typedef uint64_t EventParam;

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -36,6 +36,12 @@ typedef struct {
     EventParam param_2;
 } Event;
 
+enum class AuthState : uint64_t {
+    Pending = 0,
+    Failed = 1,
+    Success = 2,
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/src/event.hpp
+++ b/cpp/src/event.hpp
@@ -36,12 +36,6 @@ typedef struct {
     EventParam param_2;
 } Event;
 
-enum class AuthState : uint64_t {
-    Pending = 0,
-    Failed = 1,
-    Success = 2,
-};
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025, Nathan Gill
 
 #include "event_handler.hpp"
+#include "interface.hpp"
 #include "keyboard.hpp"
 #include "logging.hpp"
 #include "pointer.hpp"
@@ -73,6 +74,8 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
             break;
         }
         case EventType::AuthStateUpdate: {
+            emit m_renderer->interface->authStateChange(
+                static_cast<Interface::AuthState>(param_1));
             debug_log(
                 FILENAME,
                 format_log("Received AuthStateUpdate: ", param_1).c_str());

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -76,9 +76,6 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
         case EventType::AuthStateUpdate: {
             emit m_renderer->interface->authStateChange(
                 static_cast<Interface::AuthState>(param_1));
-            debug_log(
-                FILENAME,
-                format_log("Received AuthStateUpdate: ", param_1).c_str());
             break;
         }
     }

--- a/cpp/src/event_handler.cpp
+++ b/cpp/src/event_handler.cpp
@@ -72,6 +72,12 @@ int EventHandler::processEvent(EventType event_type, EventParam param_1,
                 param_1, static_cast<ButtonState>(param_2));
             break;
         }
+        case EventType::AuthStateUpdate: {
+            debug_log(
+                FILENAME,
+                format_log("Received AuthStateUpdate: ", param_1).c_str());
+            break;
+        }
     }
 
     debug_log(FILENAME,

--- a/cpp/src/interface.cpp
+++ b/cpp/src/interface.cpp
@@ -23,3 +23,19 @@ Q_INVOKABLE void Interface::sendAuthSubmit(const QString &msg) {
     debug_log(FILENAME, "Sent AuthSubmit event to authenticator");
 }
 
+Q_INVOKABLE void Interface::debug(const QString &msg) {
+    debug_log(m_renderer->appState->qmlPath, msg.toStdString().c_str());
+}
+
+Q_INVOKABLE void Interface::info(const QString &msg) {
+    info_log(m_renderer->appState->qmlPath, msg.toStdString().c_str());
+}
+
+Q_INVOKABLE void Interface::warn(const QString &msg) {
+    warn_log(m_renderer->appState->qmlPath, msg.toStdString().c_str());
+}
+
+Q_INVOKABLE void Interface::error(const QString &msg) {
+    error_log(m_renderer->appState->qmlPath, msg.toStdString().c_str());
+}
+

--- a/cpp/src/interface.cpp
+++ b/cpp/src/interface.cpp
@@ -22,3 +22,4 @@ Q_INVOKABLE void Interface::sendAuthSubmit(const QString &msg) {
                reinterpret_cast<EventParam>(fbu), 0);
     debug_log(FILENAME, "Sent AuthSubmit event to authenticator");
 }
+

--- a/cpp/src/interface.hpp
+++ b/cpp/src/interface.hpp
@@ -21,6 +21,11 @@ public:
     ~Interface();
 
     Q_INVOKABLE void sendAuthSubmit(const QString &msg);
+    
+    Q_INVOKABLE void debug(const QString &msg);
+    Q_INVOKABLE void info(const QString &msg);
+    Q_INVOKABLE void warn(const QString &msg);
+    Q_INVOKABLE void error(const QString &msg);
 
     enum AuthState {
         Pending = 0,

--- a/cpp/src/interface.hpp
+++ b/cpp/src/interface.hpp
@@ -21,6 +21,16 @@ public:
     ~Interface();
 
     Q_INVOKABLE void sendAuthSubmit(const QString &msg);
+
+    enum AuthState {
+        Pending = 0,
+        Failed = 1,
+        Success = 2,
+    };
+    Q_ENUM(AuthState)
+
+signals:
+    void authStateChange(AuthState state);
 };
 
 #endif

--- a/cpp/src/render.cpp
+++ b/cpp/src/render.cpp
@@ -42,7 +42,6 @@ QmlRenderer *initialize_renderer(int width, int height, const char *qmlPath,
     renderer->fbSize = QSize(width, height);
     renderer->qmlPath = qmlPath;
     renderer->appState = appState;
-    renderer->interface = new Interface(renderer);
 
     renderer->eventHandler = new EventHandler(renderer);
 
@@ -148,6 +147,8 @@ void setup_renderer(QmlRenderer *renderer) {
     renderer->window->setRenderTarget(renderTarget);
 
     renderer->engine = new QQmlEngine();
+
+    renderer->interface = new Interface(renderer);
 
     // Expose the `tlockr` interface to the QML
     renderer->engine->rootContext()->setContextProperty("tlockr",

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::{
     shared::state::{ApplicationState, ApplicationStatePtr},
     wayland::state::WaylandState,
 };
-use nix::{libc};
+use nix::libc;
 use std::{
     env,
     ffi::CString,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use crate::{
     shared::state::{ApplicationState, ApplicationStatePtr},
     wayland::state::WaylandState,
 };
-use nix::libc;
+use nix::{libc};
 use std::{
     env,
     ffi::CString,
@@ -63,14 +63,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut event_queue = state.initialize()?;
 
     // TODO: Store pipe fd in ApplicationState
-    auth_state.initialize(
-        state
-            .renderer_write_pipe
-            .as_ref()
-            .unwrap()
-            .write_fd()
-            .as_raw_fd(),
-    )?;
+    auth_state.initialize(state.renderer_write_pipe.as_ref().unwrap().write_fd())?;
 
     let auth_thread = std::thread::spawn(move || {
         info!("Authentication thread started");

--- a/src/wayland/event/event_type.rs
+++ b/src/wayland/event/event_type.rs
@@ -24,9 +24,7 @@ pub enum EventType {
     PointerButton = 8,
 
     AuthSubmit = 9,
-    AuthPending = 10,
-    AuthFail = 11,
-    AuthSuccess = 12,
+    AuthStateUpdate = 10,
 }
 
 impl TryFrom<u64> for EventType {
@@ -47,9 +45,7 @@ impl TryFrom<u64> for EventType {
             8 => Ok(EventType::PointerButton),
 
             9 => Ok(EventType::AuthSubmit),
-            10 => Ok(EventType::AuthPending),
-            11 => Ok(EventType::AuthFail),
-            12 => Ok(EventType::AuthSuccess),
+            10 => Ok(EventType::AuthStateUpdate),
             _ => Err("Invalid EventType tag"),
         }
     }

--- a/test/test_lock.qml
+++ b/test/test_lock.qml
@@ -94,4 +94,11 @@ Rectangle {
         color: "#666666"
         font.pixelSize: 12
     }
+
+    Connections {
+        target: tlockr
+        function onAuthStateChange(state) {
+            console.log(`Updated state: ${state}`)
+        }
+    }
 }

--- a/test/test_lock.qml
+++ b/test/test_lock.qml
@@ -98,7 +98,7 @@ Rectangle {
     Connections {
         target: tlockr
         function onAuthStateChange(state) {
-            console.log(`Updated state: ${state}`)
+            tlockr.info(`Updated state: ${state}`)
         }
     }
 }


### PR DESCRIPTION
Send authentication state events to Qt to allow loaded content to determine when authentication is pending, failed, or succeeds. 