### PR TITLE
feat: add basic light and dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ To avoid this, when developing themes, it is a good idea to run tlockr in a disp
 pipe the logs back to your main session. That way, if you get locked out, you can safely kill the other
 compositor.
 
+A basic theme is included with tlockr, inspired by [where-is-my-sddm-theme](https://github.com/stepanzubkov/where-is-my-sddm-theme). This includes light and dark variants,
+both can be found in the `themes` directory of this repository.
+
 ## Contributing
 
 Contributions to tlockr are always welcome!

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ tlockr provides interfaces for connecting QML themes with the rest of the applic
 - `tlockr.sendAuthSubmit`: submits authentication information, the only argument is the password as a string.
 - `tlockr.{debug,info,warn,error}`: logging functions that send log messages (as strings) to the `tlockr` logger.
 - `tlockr.onAuthStateChange`: signal emitted when the authentication state changes, the state is passed.
+- `tlockr.Width`: width of display output in pixels.
+- `tlockr.Height`: height of displat output in pixels.
 - Future interfaces planned...
 
 When tlockr loads QML content, any errors are displayed in the log.

--- a/cpp/src/interface.cpp
+++ b/cpp/src/interface.cpp
@@ -39,3 +39,8 @@ Q_INVOKABLE void Interface::error(const QString &msg) {
     error_log(m_renderer->appState->qmlPath, msg.toStdString().c_str());
 }
 
+int Interface::outputWidth() const { return m_renderer->appState->outputWidth; }
+
+int Interface::outputHeight() const {
+    return m_renderer->appState->outputHeight;
+}

--- a/cpp/src/interface.hpp
+++ b/cpp/src/interface.hpp
@@ -13,6 +13,9 @@ struct QmlRenderer;
 
 class Interface : public QObject {
     Q_OBJECT
+    Q_PROPERTY(int Width READ outputWidth CONSTANT)
+    Q_PROPERTY(int Height READ outputHeight CONSTANT)
+
 private:
     QmlRenderer *m_renderer;
 
@@ -26,6 +29,9 @@ public:
     Q_INVOKABLE void info(const QString &msg);
     Q_INVOKABLE void warn(const QString &msg);
     Q_INVOKABLE void error(const QString &msg);
+
+    int outputWidth() const;
+    int outputHeight() const;
 
     enum AuthState {
         Pending = 0,

--- a/cpp/src/interface.hpp
+++ b/cpp/src/interface.hpp
@@ -21,7 +21,7 @@ public:
     ~Interface();
 
     Q_INVOKABLE void sendAuthSubmit(const QString &msg);
-    
+
     Q_INVOKABLE void debug(const QString &msg);
     Q_INVOKABLE void info(const QString &msg);
     Q_INVOKABLE void warn(const QString &msg);

--- a/cpp/src/render.hpp
+++ b/cpp/src/render.hpp
@@ -51,6 +51,8 @@ struct ApplicationState {
     int rendererReadFd;
     int authWriteFd;
     int authReadFd;
+    int outputWidth;
+    int outputHeight;
 };
 
 struct QmlRenderer {

--- a/src/shared/interface.rs
+++ b/src/shared/interface.rs
@@ -44,6 +44,8 @@ safe_getter!(get_auth_read_fd, auth_read_fd, c_int);
 safe_getter!(get_auth_write_fd, auth_write_fd, c_int);
 safe_getter!(get_renderer, renderer, *mut QmlRenderer);
 safe_getter!(get_qml_path, qml_path, *mut c_char);
+safe_getter!(get_output_width, output_width, c_int);
+safe_getter!(get_output_height, output_height, c_int);
 
 safe_setter!(set_state, state, State);
 safe_setter!(set_renderer_read_fd, renderer_read_fd, c_int);
@@ -52,3 +54,5 @@ safe_setter!(set_auth_read_fd, auth_read_fd, c_int);
 safe_setter!(set_auth_write_fd, auth_write_fd, c_int);
 safe_setter!(set_renderer, renderer, *mut QmlRenderer);
 safe_setter!(set_qml_path, qml_path, *mut c_char);
+safe_setter!(set_output_width, output_width, c_int);
+safe_setter!(set_output_height, output_height, c_int);

--- a/src/shared/state.rs
+++ b/src/shared/state.rs
@@ -31,6 +31,8 @@ pub struct ApplicationState {
     pub renderer_read_fd: c_int,
     pub auth_write_fd: c_int,
     pub auth_read_fd: c_int,
+    pub output_width: c_int,
+    pub output_height: c_int,
 }
 
 impl ApplicationState {
@@ -43,6 +45,8 @@ impl ApplicationState {
             renderer_read_fd: -1,
             auth_write_fd: -1,
             auth_read_fd: -1,
+            output_width: -1,
+            output_height: -1,
         }
     }
 }

--- a/src/wayland/graphics/output.rs
+++ b/src/wayland/graphics/output.rs
@@ -6,6 +6,7 @@
         Contains a dispatch method to obtain the output display dimensions.
 */
 
+use crate::shared::interface::{set_output_height, set_output_width};
 use crate::wayland::state::WaylandState;
 use tracing::debug;
 use wayland_client::{
@@ -33,6 +34,9 @@ impl Dispatch<WlOutput, ()> for WaylandState {
                     debug!("Output mode: {} x {} pixels", width, height);
                     state.width = width;
                     state.height = height;
+
+                    set_output_width(state.app_state, width);
+                    set_output_height(state.app_state, height);
                 }
             }
             wl_output::Event::Done => {

--- a/themes/basic_dark.qml
+++ b/themes/basic_dark.qml
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+import QtQuick 2.15
+import QtQuick.Controls 2.0
+
+import Qt5Compat.GraphicalEffects
+
+Rectangle {
+    id: root
+    width: 640
+    height: 480
+
+    Connections {
+        target: tlockr
+        function onAuthStateChange(state) {
+            if (state == 1) {   // Login failed
+                backgroundBorder.border.width = 5;
+                animateBorder.restart();
+                passwordInput.clear(); 
+            } else if (state == 2) {    // Login success
+                backgroundBorder.border.width = 0;
+                animateBorder.stop();
+            }
+        }
+    }
+
+    Item {
+        id: mainFrame
+
+        // Don't hardcode these
+        x: 0
+        y: 0
+        width: 1920
+        height: 1200
+        
+        Rectangle {
+            id: background
+            visible: true
+            anchors.fill: parent
+            color: "#000000"
+
+            Rectangle {
+                id: backgroundBorder
+                anchors.fill: parent
+                z: 4
+                border.color: "#FF0000"
+                border.width: 0
+                color: "transparent"
+
+                Behavior on border.width {
+                    SequentialAnimation {
+                        id: animateBorder
+                        running: false
+                        loops: Animation.Infinite                        
+                        NumberAnimation { from: 5; to: 10; duration: 700 }
+                        NumberAnimation { from: 10; to: 5; duration: 400 }
+                    }
+                }
+            }          
+        }
+
+        TextInput {
+            id: passwordInput
+            width: parent.width * 0.5
+            height: 200
+            font.pointSize: 96
+            font.bold: true
+            font.letterSpacing: 20
+            font.family: "monospace"
+            anchors {
+                verticalCenter: parent.verticalCenter
+                horizontalCenter: parent.horizontalCenter
+            }
+            echoMode: TextInput.Password
+            color: "#FFFFFF"
+            selectionColor: "#FFFFFF"
+            selectedTextColor: "#000000"
+            clip: true
+            horizontalAlignment: TextInput.AlignHCenter
+            verticalAlignment: TextInput.AlignVCenter
+            passwordCharacter: "*"
+            cursorVisible: false
+            activeFocusOnTab: false
+            focus: true
+
+            onAccepted: {
+                if (text != "") {
+                    tlockr.sendAuthSubmit(text);
+                }
+            }
+        }
+
+        Component.onCompleted: {
+            Qt.callLater(function() {
+                passwordInput.forceActiveFocus();
+                passwordInput.cursorVisible = false;
+            });
+        }
+    }
+
+    Loader {
+        active: true
+        anchors.fill: parent
+        sourceComponent: MouseArea {
+            enabled: false
+            cursorShape: Qt.BlankCursor
+        }
+    }
+}

--- a/themes/basic_dark.qml
+++ b/themes/basic_dark.qml
@@ -27,12 +27,8 @@ Rectangle {
 
     Item {
         id: mainFrame
-
-        // Don't hardcode these
-        x: 0
-        y: 0
-        width: 1920
-        height: 1200
+        width: tlockr.Width
+        height: tlockr.Height
         
         Rectangle {
             id: background

--- a/themes/basic_light.qml
+++ b/themes/basic_light.qml
@@ -27,12 +27,8 @@ Rectangle {
 
     Item {
         id: mainFrame
-
-        // Don't hardcode these
-        x: 0
-        y: 0
-        width: 1920
-        height: 1200
+        width: tlockr.Width
+        height: tlockr.Height
         
         Rectangle {
             id: background

--- a/themes/basic_light.qml
+++ b/themes/basic_light.qml
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025, Nathan Gill
+
+import QtQuick 2.15
+import QtQuick.Controls 2.0
+
+import Qt5Compat.GraphicalEffects
+
+Rectangle {
+    id: root
+    width: 640
+    height: 480
+
+    Connections {
+        target: tlockr
+        function onAuthStateChange(state) {
+            if (state == 1) {   // Login failed
+                backgroundBorder.border.width = 5;
+                animateBorder.restart();
+                passwordInput.clear(); 
+            } else if (state == 2) {    // Login success
+                backgroundBorder.border.width = 0;
+                animateBorder.stop();
+            }
+        }
+    }
+
+    Item {
+        id: mainFrame
+
+        // Don't hardcode these
+        x: 0
+        y: 0
+        width: 1920
+        height: 1200
+        
+        Rectangle {
+            id: background
+            visible: true
+            anchors.fill: parent
+            color: "#FFFFFF"
+
+            Rectangle {
+                id: backgroundBorder
+                anchors.fill: parent
+                z: 4
+                border.color: "#FF0000"
+                border.width: 0
+                color: "transparent"
+
+                Behavior on border.width {
+                    SequentialAnimation {
+                        id: animateBorder
+                        running: false
+                        loops: Animation.Infinite                        
+                        NumberAnimation { from: 5; to: 10; duration: 700 }
+                        NumberAnimation { from: 10; to: 5; duration: 400 }
+                    }
+                }
+            }          
+        }
+
+        TextInput {
+            id: passwordInput
+            width: parent.width * 0.5
+            height: 200
+            font.pointSize: 96
+            font.bold: true
+            font.letterSpacing: 20
+            font.family: "monospace"
+            anchors {
+                verticalCenter: parent.verticalCenter
+                horizontalCenter: parent.horizontalCenter
+            }
+            echoMode: TextInput.Password
+            color: "#000000"
+            selectionColor: "#000000"
+            selectedTextColor: "#FFFFFF"
+            clip: true
+            horizontalAlignment: TextInput.AlignHCenter
+            verticalAlignment: TextInput.AlignVCenter
+            passwordCharacter: "*"
+            cursorVisible: false
+            activeFocusOnTab: false
+            focus: true
+
+            onAccepted: {
+                if (text != "") {
+                    tlockr.sendAuthSubmit(text);
+                }
+            }
+        }
+
+        Component.onCompleted: {
+            Qt.callLater(function() {
+                passwordInput.forceActiveFocus();
+                passwordInput.cursorVisible = false;
+            });
+        }
+    }
+
+    Loader {
+        active: true
+        anchors.fill: parent
+        sourceComponent: MouseArea {
+            enabled: false
+            cursorShape: Qt.BlankCursor
+        }
+    }
+}


### PR DESCRIPTION
Add basic light and dark themes inspired by [where-is-my-sddm-theme](https://github.com/stepanzubkov/where-is-my-sddm-theme).

Also add an interface to get output width and height, for use by these themes.